### PR TITLE
fix: make test target depend on dbt-manifest

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,10 +8,10 @@ lint:
 fix:
 	cd macro_agents && uv sync --extra dev && uv run sqlfluff fix ../dbt_project/models --disable-progress-bar --processes 4
 
-test:
+test: dbt-manifest
 	cd macro_agents && uv sync --extra dev && uv run pytest tests/ -v
 
-test-dagster:
+test-dagster: dbt-manifest
 	cd macro_agents && uv sync --extra dev && uv run pytest tests/ -v
 
 typecheck-dagster:


### PR DESCRIPTION
## Summary
- `make test` fails on a fresh clone because `tests/test_integration.py` and `tests/test_schedules.py` import the dbt assets module, which requires `dbt_project/target/manifest.json` to exist.
- This change makes `test` and `test-dagster` depend on `dbt-manifest`, so a fresh clone can run `make test` straight through.

Verified on a fresh clone:
- before: `make test` → 2 collection errors (manifest not found)
- after: `make test` → 431 passed in 14.84s

🤖 Generated with [Claude Code](https://claude.com/claude-code)