### PR TITLE
fix(security): address audit findings (token leak, SQLi, infra hardening)

### DIFF
--- a/.github/workflows/dagster-ci.yml
+++ b/.github/workflows/dagster-ci.yml
@@ -18,20 +18,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
         with:
           version: "latest"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-dagster-${{ hashFiles('macro_agents/pyproject.toml', 'macro_agents/uv.lock') }}

--- a/.github/workflows/dagster-oss-deploy.yml
+++ b/.github/workflows/dagster-oss-deploy.yml
@@ -28,17 +28,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 1
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f  # v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
@@ -109,37 +109,28 @@ jobs:
           echo "Deployment completed"
 
       - name: Health check
+        # Probe the Dagster webserver from inside the VM via SSH rather than
+        # hitting an external IP over plain HTTP. The Terraform firewall
+        # rejects external traffic on port 3000 (access is via IAP), so the
+        # old external-IP curl was both insecure and bypassed that intent.
         run: |
-          echo "Performing health check..."
-
-          # Get VM external IP
-          EXTERNAL_IP=$(gcloud compute instances describe $VM_NAME --zone=$GCP_ZONE --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
-          echo "VM External IP: $EXTERNAL_IP"
-
-          # Wait for Dagster UI to be ready
-          echo "Waiting for Dagster UI to be accessible..."
-          sleep 30
-
-          # Try to access Dagster UI
+          echo "Performing health check via SSH..."
           MAX_RETRIES=10
           RETRY_COUNT=0
+          sleep 30
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            if curl -f -s -o /dev/null http://$EXTERNAL_IP:3000; then
-              echo "✅ Dagster UI is accessible at http://$EXTERNAL_IP:3000"
+            if gcloud compute ssh "$VM_NAME" --zone="$GCP_ZONE" --command='curl -f -s -o /dev/null http://localhost:3000'; then
+              echo "Dagster UI is healthy (responding on localhost:3000 inside VM)"
               exit 0
-            else
-              echo "Attempt $((RETRY_COUNT + 1))/$MAX_RETRIES: Dagster UI not ready yet..."
-              RETRY_COUNT=$((RETRY_COUNT + 1))
-              sleep 10
             fi
+            echo "Attempt $((RETRY_COUNT + 1))/$MAX_RETRIES: Dagster UI not ready yet..."
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            sleep 10
           done
 
-          echo "❌ Health check failed - Dagster UI not accessible after $MAX_RETRIES attempts"
-
-          # Collect logs for debugging
-          gcloud compute ssh $VM_NAME --zone=$GCP_ZONE --command='docker compose logs --tail=100'
-
+          echo "Health check failed - Dagster UI not accessible after $MAX_RETRIES attempts"
+          gcloud compute ssh "$VM_NAME" --zone="$GCP_ZONE" --command='docker compose logs --tail=100'
           exit 1
 
       - name: Verify deployment
@@ -168,15 +159,12 @@ jobs:
       - name: Notify on failure
         if: failure()
         run: |
-          echo "⚠️ Deployment failed! Check the logs above for details."
-          EXTERNAL_IP=$(gcloud compute instances describe $VM_NAME --zone=$GCP_ZONE --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
-          echo "You can manually check the VM at: $EXTERNAL_IP"
+          echo "Deployment failed! Check the logs above for details."
           echo "SSH command: gcloud compute ssh $VM_NAME --zone=$GCP_ZONE"
 
       - name: Notify on success
         if: success()
         run: |
-          EXTERNAL_IP=$(gcloud compute instances describe $VM_NAME --zone=$GCP_ZONE --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
-          echo "✅ Deployment successful!"
-          echo "Dagster UI: http://$EXTERNAL_IP:3000"
+          echo "Deployment successful."
+          echo "Dagster UI is exposed via IAP (not direct external IP)."
           echo "To view logs: gcloud compute ssh $VM_NAME --zone=$GCP_ZONE --command='cd ~/dagster && docker compose logs -f'"

--- a/dbt_project/profiles.yml
+++ b/dbt_project/profiles.yml
@@ -8,6 +8,13 @@ econ_database:
       threads: 1
     
     prod:  # Keep prod target for backwards compatibility
+      # SECURITY: dbt-duckdb requires the MotherDuck token inside the path
+      # string. dbt may emit this value in DEBUG-level logs and write it
+      # into target/ artifacts (run_results.json, manifest.json).
+      # Mitigations:
+      #   1. Never raise log level above INFO in production runs.
+      #   2. Never publish dbt_project/target/ or logs/ as build artifacts.
+      #   3. Rotate MOTHERDUCK_TOKEN if a log or artifact is ever exfiltrated.
       type: duckdb
       schema: "{{ env_var('MOTHERDUCK_PROD_SCHEMA') }}"
       path: "md:{{ env_var('MOTHERDUCK_DATABASE') }}?motherduck_token={{ env_var('MOTHERDUCK_TOKEN') }}"

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -136,8 +136,18 @@ resource "google_compute_instance" "dagster" {
   }
 
   service_account {
-    email  = google_service_account.dagster_vm.email
-    scopes = ["cloud-platform"]
+    email = google_service_account.dagster_vm.email
+    # Narrow the OAuth scope envelope to what the VM actually needs. The
+    # service account's IAM roles still gate API access, but constraining
+    # scopes here means a compromised process on the VM can't request
+    # tokens for unrelated APIs (Compute Engine admin, Cloud SQL, etc.).
+    scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_write",
+      "https://www.googleapis.com/auth/bigquery",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring.write",
+      "https://www.googleapis.com/auth/cloud-platform.read-only",
+    ]
   }
 
   metadata = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,8 @@ services:
       REDDIT_CLIENT_ID: ${REDDIT_CLIENT_ID}
       REDDIT_CLIENT_SECRET: ${REDDIT_CLIENT_SECRET}
       GITHUB_TOKEN: ${GITHUB_TOKEN}
-      GITHUB_REPO_OWNER: ${GITHUB_REPO_OWNER:-C00ldudeNoonan}
-      GITHUB_REPO_NAME: ${GITHUB_REPO_NAME:-economic-data-project-full}
+      GITHUB_REPO_OWNER: ${GITHUB_REPO_OWNER:?GITHUB_REPO_OWNER must be set}
+      GITHUB_REPO_NAME: ${GITHUB_REPO_NAME:?GITHUB_REPO_NAME must be set}
 
 
     volumes:
@@ -214,8 +214,8 @@ services:
       REDDIT_CLIENT_ID: ${REDDIT_CLIENT_ID}
       REDDIT_CLIENT_SECRET: ${REDDIT_CLIENT_SECRET}
       GITHUB_TOKEN: ${GITHUB_TOKEN}
-      GITHUB_REPO_OWNER: ${GITHUB_REPO_OWNER:-C00ldudeNoonan}
-      GITHUB_REPO_NAME: ${GITHUB_REPO_NAME:-economic-data-project-full}
+      GITHUB_REPO_OWNER: ${GITHUB_REPO_OWNER:?GITHUB_REPO_OWNER must be set}
+      GITHUB_REPO_NAME: ${GITHUB_REPO_NAME:?GITHUB_REPO_NAME must be set}
     volumes:
       - ./dagster.yaml:/opt/dagster/dagster_home/dagster.yaml:ro
       - ./workspace.yaml:/opt/dagster/dagster_home/workspace.yaml:ro

--- a/macro_agents/pyproject.toml
+++ b/macro_agents/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "networkx>=3.2.0,<4.0.0",
     "pdfplumber>=0.11.0,<1.0.0",
     "vadersentiment>=3.3.2",
+    "sqlglot>=25.0.0,<27.0.0",
 ]
 
 [project.optional-dependencies]

--- a/macro_agents/src/macro_agents/defs/analysis/ai/nl_to_sql_module.py
+++ b/macro_agents/src/macro_agents/defs/analysis/ai/nl_to_sql_module.py
@@ -133,7 +133,10 @@ class SQLValidator:
             return False, "SQL query is empty"
 
         if len(sql) > SQLValidator.MAX_QUERY_LENGTH:
-            return False, f"Query is too long (max {SQLValidator.MAX_QUERY_LENGTH} characters)"
+            return (
+                False,
+                f"Query is too long (max {SQLValidator.MAX_QUERY_LENGTH} characters)",
+            )
 
         try:
             statements = sqlglot.parse(sql, dialect="duckdb")
@@ -144,11 +147,15 @@ class SQLValidator:
         if len(non_empty) == 0:
             return False, "SQL query is empty"
         if len(non_empty) > 1:
-            return False, "Multiple SQL statements detected. Only single SELECT queries allowed."
+            return (
+                False,
+                "Multiple SQL statements detected. Only single SELECT queries allowed.",
+            )
 
         root = non_empty[0]
         if not isinstance(root, exp.Select) and not (
-            isinstance(root, (exp.Union, exp.Subquery)) and root.find(exp.Select) is not None
+            isinstance(root, (exp.Union, exp.Subquery))
+            and root.find(exp.Select) is not None
         ):
             return False, "Only SELECT queries are allowed."
 

--- a/macro_agents/src/macro_agents/defs/analysis/ai/nl_to_sql_module.py
+++ b/macro_agents/src/macro_agents/defs/analysis/ai/nl_to_sql_module.py
@@ -1,6 +1,8 @@
 """Natural Language to SQL Module - Converts user questions to SQL queries using DSPy."""
 
 import dspy
+import sqlglot
+from sqlglot import exp
 
 
 class NaturalLanguageToSQLSignature(dspy.Signature):
@@ -92,77 +94,67 @@ class NaturalLanguageToSQLModule(dspy.Module):
 
 
 class SQLValidator:
-    """Validates SQL queries for safety and correctness."""
+    """Validates SQL queries for safety and correctness.
 
-    # Keywords that are forbidden in user-generated SQL
-    FORBIDDEN_KEYWORDS = [
-        "DROP",
-        "DELETE",
-        "UPDATE",
-        "INSERT",
-        "ALTER",
-        "CREATE",
-        "TRUNCATE",
-        "GRANT",
-        "REVOKE",
-        "EXEC",
-        "EXECUTE",
-    ]
+    Uses sqlglot to parse the query into an AST and verify it is a single
+    read-only SELECT. The prior implementation matched forbidden keywords
+    as substrings of the raw string, which was bypassable by comments,
+    mixed case, and embedded newlines.
+    """
+
+    # AST node types that mutate or escape data — reject if present anywhere.
+    FORBIDDEN_NODES: tuple[type[exp.Expression], ...] = (
+        exp.Insert,
+        exp.Update,
+        exp.Delete,
+        exp.Drop,
+        exp.Create,
+        exp.Alter,
+        exp.TruncateTable,
+        exp.Grant,
+        exp.Command,  # Generic fallback (e.g. REVOKE, EXECUTE) that sqlglot doesn't model explicitly.
+        exp.Transaction,
+        exp.Rollback,
+        exp.Commit,
+    )
+
+    MAX_QUERY_LENGTH = 10000
 
     @staticmethod
     def validate_query(sql: str) -> tuple[bool, str]:
-        """
-        Validate SQL query for safety and correctness.
+        """Validate SQL query for safety and correctness.
 
-        Args:
-            sql: SQL query string to validate
-
-        Returns:
-            Tuple of (is_valid, error_message)
-            - is_valid: True if query passes all checks, False otherwise
-            - error_message: Empty string if valid, error description if invalid
+        Returns ``(is_valid, error_message)``. Parses to AST and rejects any
+        statement that isn't a single SELECT — bypass attempts via comments,
+        case mixing, or whitespace tricks cannot succeed because the parser
+        normalizes them before validation runs.
         """
         if not sql or not sql.strip():
             return False, "SQL query is empty"
 
-        sql_stripped = sql.strip()
-        sql_upper = sql_stripped.upper()
+        if len(sql) > SQLValidator.MAX_QUERY_LENGTH:
+            return False, f"Query is too long (max {SQLValidator.MAX_QUERY_LENGTH} characters)"
 
-        # Must start with SELECT
-        if not sql_upper.startswith("SELECT"):
-            return (
-                False,
-                "Only SELECT queries are allowed. Query must start with SELECT.",
-            )
+        try:
+            statements = sqlglot.parse(sql, dialect="duckdb")
+        except sqlglot.errors.ParseError as e:
+            return False, f"SQL parse error: {e}"
 
-        # Check for forbidden keywords
-        for keyword in SQLValidator.FORBIDDEN_KEYWORDS:
-            # Use word boundaries to avoid false positives (e.g., "SELECT" contains "ELECT")
-            if f" {keyword} " in f" {sql_upper} " or sql_upper.startswith(
-                f"{keyword} "
-            ):
-                return (
-                    False,
-                    f"Forbidden keyword detected: {keyword}. Only SELECT queries are allowed.",
-                )
+        non_empty = [s for s in statements if s is not None]
+        if len(non_empty) == 0:
+            return False, "SQL query is empty"
+        if len(non_empty) > 1:
+            return False, "Multiple SQL statements detected. Only single SELECT queries allowed."
 
-        # Check for semicolons (could indicate SQL injection attempt)
-        semicolon_count = sql_stripped.count(";")
-        if semicolon_count > 1:
-            return (
-                False,
-                "Multiple SQL statements detected (multiple semicolons). Only single SELECT queries allowed.",
-            )
+        root = non_empty[0]
+        if not isinstance(root, exp.Select) and not (
+            isinstance(root, (exp.Union, exp.Subquery)) and root.find(exp.Select) is not None
+        ):
+            return False, "Only SELECT queries are allowed."
 
-        # Remove trailing semicolon for validation if present
-        if sql_stripped.endswith(";"):
-            sql_for_validation = sql_stripped[:-1].strip()
-        else:
-            sql_for_validation = sql_stripped
-
-        # Basic length check (prevent extremely long queries)
-        if len(sql_for_validation) > 10000:
-            return False, "Query is too long (max 10,000 characters)"
+        for node in root.walk():
+            if isinstance(node, SQLValidator.FORBIDDEN_NODES):
+                return False, f"Forbidden statement type: {type(node).__name__}"
 
         return True, ""
 

--- a/macro_agents/src/macro_agents/defs/domains/housing.py
+++ b/macro_agents/src/macro_agents/defs/domains/housing.py
@@ -54,7 +54,7 @@ def housing_inventory_raw(
         context.log.error(
             f"Failed to fetch housing inventory data: {response.status_code}"
         )
-        context.log.error(f"Response: {response.text}")
+        context.log.error(f"Response: {response.text[:200]}")
         raise Exception(
             f"Failed to fetch housing inventory data: {response.status_code}"
         )

--- a/macro_agents/src/macro_agents/defs/resources/motherduck.py
+++ b/macro_agents/src/macro_agents/defs/resources/motherduck.py
@@ -1,12 +1,26 @@
 import io
 import logging
 import os
+import re
 from typing import Any
 
 import dagster as dg
 import duckdb
 import polars as pl
 from pydantic import Field
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$")
+
+
+def _validate_identifier(name: str, kind: str = "identifier") -> str:
+    """Reject any string that isn't a plain SQL identifier or schema.table.
+
+    Why: identifiers can't be parameterized in DuckDB. Callers that interpolate
+    table or column names need a strict allowlist to prevent SQL injection.
+    """
+    if not isinstance(name, str) or not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"Invalid {kind}: {name!r}")
+    return name
 
 
 class MotherDuckResource(dg.ConfigurableResource):
@@ -558,6 +572,8 @@ class MotherDuckResource(dg.ConfigurableResource):
     # Enhanced methods for querying and data analysis
     def get_unique_categories(self, table_name: str, column: str) -> list[str]:
         """Get unique values from a specified column."""
+        _validate_identifier(table_name, "table name")
+        _validate_identifier(column, "column name")
         query = f"SELECT DISTINCT {column} FROM {table_name} WHERE {column} IS NOT NULL ORDER BY {column}"
         conn = None
         try:
@@ -576,16 +592,26 @@ class MotherDuckResource(dg.ConfigurableResource):
         sampling_strategy: str = "top_correlations",
     ) -> str:
         """Query sampled data from DuckDB with various sampling strategies."""
-        where_conditions = []
+        _validate_identifier(table_name, "table name")
+        if not isinstance(sample_size, int) or sample_size <= 0:
+            raise ValueError(f"Invalid sample_size: {sample_size!r}")
+        if sampling_strategy not in {"top_correlations", "random", "mixed"}:
+            raise ValueError(f"Unknown sampling strategy: {sampling_strategy}")
+
+        where_conditions: list[str] = []
+        query_params: list[Any] = []
         if filters:
             for column, value in filters.items():
-                if isinstance(value, str):
-                    where_conditions.append(f"{column} = '{value}'")
-                elif isinstance(value, list):
-                    value_str = "', '".join(str(v) for v in value)
-                    where_conditions.append(f"{column} IN ('{value_str}')")
+                _validate_identifier(column, "filter column")
+                if isinstance(value, list):
+                    if not value:
+                        continue
+                    placeholders = ", ".join("?" for _ in value)
+                    where_conditions.append(f"{column} IN ({placeholders})")
+                    query_params.extend(value)
                 else:
-                    where_conditions.append(f"{column} = {value}")
+                    where_conditions.append(f"{column} = ?")
+                    query_params.append(value)
 
         where_clause = (
             " WHERE " + " AND ".join(where_conditions) if where_conditions else ""
@@ -630,13 +656,13 @@ class MotherDuckResource(dg.ConfigurableResource):
                     LIMIT {sample_size - half_size}
                 )
             """
-        else:
-            raise ValueError(f"Unknown sampling strategy: {sampling_strategy}")
+            # The mixed query references where_clause twice; duplicate the bound params to match.
+            query_params = query_params + query_params
 
         conn = None
         try:
             conn = self.get_connection()
-            df = conn.execute(query).pl()
+            df = conn.execute(query, query_params).pl()
             csv_buffer = io.StringIO()
             df.write_csv(csv_buffer)
             return csv_buffer.getvalue()

--- a/macro_agents/src/macro_agents/defs/resources/motherduck.py
+++ b/macro_agents/src/macro_agents/defs/resources/motherduck.py
@@ -23,8 +23,13 @@ class MotherDuckResource(dg.ConfigurableResource):
     environment: str = Field(description="Environment (dev or prod)", default="LOCAL")
 
     @property
-    def db_connection(self) -> str:
-        """Get the database connection string based on environment."""
+    def _db_connection(self) -> str:
+        """Internal: connection string, may contain the MotherDuck token.
+
+        Why: returning this from a public method risks leaking the token into
+        Dagster logs, exception traces, and asset metadata. Keep it private and
+        only pass it directly to ``duckdb.connect``.
+        """
         if self.environment == "dev":
             return self.local_path
         return f"md:?motherduck_token={self.md_token}"
@@ -41,16 +46,16 @@ class MotherDuckResource(dg.ConfigurableResource):
             ):
                 try:
                     # Try to connect - if it fails with IO error, delete the file
-                    conn = duckdb.connect(self.db_connection)
+                    conn = duckdb.connect(self._db_connection)
                 except duckdb.IOException:
                     # File exists but is not a valid DuckDB file, delete it
                     os.remove(self.local_path)
-                    conn = duckdb.connect(self.db_connection)
+                    conn = duckdb.connect(self._db_connection)
                 except Exception:
                     # For other errors, try connecting normally
-                    conn = duckdb.connect(self.db_connection)
+                    conn = duckdb.connect(self._db_connection)
             else:
-                conn = duckdb.connect(self.db_connection)
+                conn = duckdb.connect(self._db_connection)
 
             if self.environment != "dev":
                 # Create database if it doesn't exist
@@ -77,7 +82,7 @@ class MotherDuckResource(dg.ConfigurableResource):
                 time.sleep(0.5)
                 # Retry once
                 try:
-                    conn = duckdb.connect(self.db_connection)
+                    conn = duckdb.connect(self._db_connection)
                     conn.commit()
                     return conn
                 except Exception:
@@ -89,6 +94,9 @@ class MotherDuckResource(dg.ConfigurableResource):
     ) -> str:
         """
         Drop and recreate a table with the provided DataFrame data.
+
+        Returns the table name. Previously returned the connection string, which
+        could leak the MotherDuck token into Dagster logs and asset metadata.
 
         Column names are sanitized for DuckDB compatibility (spaces and special
         characters are quoted, reserved keywords are handled).
@@ -129,7 +137,7 @@ class MotherDuckResource(dg.ConfigurableResource):
         finally:
             if conn:
                 conn.close()
-        return self.db_connection
+        return table_name
 
     @staticmethod
     def sanitize_column_name(column_name: str) -> str:

--- a/macro_agents/src/macro_agents/defs/resources/nl_query_resource.py
+++ b/macro_agents/src/macro_agents/defs/resources/nl_query_resource.py
@@ -40,6 +40,16 @@ class NaturalLanguageQueryResource(dg.ConfigurableResource):
         description="Anthropic API key (required if provider='anthropic'). Can be set via ANTHROPIC_API_KEY env var.",
     )
 
+    max_calls_per_run: int = Field(
+        default=500,
+        description=(
+            "Hard cap on the number of LLM completions issued by this resource "
+            "instance. Prevents runaway spend from a misconfigured backtest "
+            "loop or sensor that fans out NL-to-SQL calls. Configure higher "
+            "for production batch jobs; set via NL_QUERY_MAX_CALLS env var."
+        ),
+    )
+
     def setup_for_execution(self, context: dg.InitResourceContext) -> None:
         """
         Initialize DSPy LM and NL-to-SQL module.
@@ -136,6 +146,7 @@ class NaturalLanguageQueryResource(dg.ConfigurableResource):
         # Initialize NL-to-SQL module and validator
         self._nl_module = NaturalLanguageToSQLModule()
         self._sql_validator = SQLValidator()
+        self._call_count = 0
 
         if log:
             log.info("NL-to-SQL module and SQL validator initialized successfully")
@@ -168,6 +179,15 @@ class NaturalLanguageQueryResource(dg.ConfigurableResource):
         """
         if context:
             context.log.info(f"Processing question: {question}")
+
+        # Enforce per-run LLM call cap to bound spend on runaway loops.
+        current = getattr(self, "_call_count", 0)
+        if current >= self.max_calls_per_run:
+            raise RuntimeError(
+                f"NL query LLM call cap reached ({self.max_calls_per_run}). "
+                f"Increase max_calls_per_run if this is expected."
+            )
+        self._call_count = current + 1
 
         # Generate SQL using DSPy module
         result = self._nl_module.forward(
@@ -226,4 +246,5 @@ nl_query_resource = NaturalLanguageQueryResource(
     openai_api_key=dg.EnvVar("OPENAI_API_KEY"),
     gemini_api_key=dg.EnvVar("GEMINI_API_KEY"),
     anthropic_api_key=dg.EnvVar("ANTHROPIC_API_KEY"),
+    max_calls_per_run=int(os.getenv("NL_QUERY_MAX_CALLS", "500")),
 )

--- a/macro_agents/src/macro_agents/defs/resources/sqlite_resource.py
+++ b/macro_agents/src/macro_agents/defs/resources/sqlite_resource.py
@@ -1,6 +1,7 @@
 """SQLite resource for accessing telemetry and user data."""
 
 import os
+import re
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
@@ -9,6 +10,19 @@ from typing import Any, Generator
 import dagster as dg
 import polars as pl
 from pydantic import Field
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_identifier(name: str, kind: str = "identifier") -> str:
+    """Reject any string that isn't a plain SQL identifier.
+
+    Why: identifiers can't be parameterized, so callers that interpolate
+    table or column names need a strict allowlist to prevent SQL injection.
+    """
+    if not isinstance(name, str) or not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"Invalid {kind}: {name!r}")
+    return name
 
 
 class SQLiteResource(dg.ConfigurableResource):
@@ -73,52 +87,55 @@ class SQLiteResource(dg.ConfigurableResource):
     def read_table_as_polars(
         self,
         table_name: str,
-        where_clause: str | None = None,
-        order_by: str | None = None,
+        where: tuple[str, tuple[Any, ...]] | None = None,
+        order_by: tuple[str, str] | None = None,
         limit: int | None = None,
     ) -> pl.DataFrame:
         """Read a SQLite table into a Polars DataFrame.
 
         Args:
-            table_name: Name of the table to read
-            where_clause: Optional WHERE clause (without the WHERE keyword)
-            order_by: Optional ORDER BY clause (without the ORDER BY keyword)
-            limit: Optional LIMIT value
-
-        Returns:
-            Polars DataFrame with the table data
+            table_name: Name of the table to read (validated as an identifier).
+            where: Optional ``(sql, params)`` pair. ``sql`` is a WHERE clause
+                body using ``?`` placeholders; ``params`` are bound safely.
+                Example: ``("id > ?", (last_id,))``.
+            order_by: Optional ``(column, direction)`` tuple. Column is validated
+                as an identifier; direction must be ``"ASC"`` or ``"DESC"``.
+            limit: Optional LIMIT value (must be a positive int).
         """
+        _validate_identifier(table_name, "table name")
         query_parts = [f"SELECT * FROM {table_name}"]
+        params: tuple[Any, ...] = ()
 
-        if where_clause:
-            query_parts.append(f"WHERE {where_clause}")
+        if where is not None:
+            where_sql, where_params = where
+            query_parts.append(f"WHERE {where_sql}")
+            params = params + tuple(where_params)
 
-        if order_by:
-            query_parts.append(f"ORDER BY {order_by}")
+        if order_by is not None:
+            column, direction = order_by
+            _validate_identifier(column, "order_by column")
+            direction_upper = direction.upper()
+            if direction_upper not in {"ASC", "DESC"}:
+                raise ValueError(f"Invalid order_by direction: {direction!r}")
+            query_parts.append(f"ORDER BY {column} {direction_upper}")
 
-        if limit:
+        if limit is not None:
+            if not isinstance(limit, int) or limit <= 0:
+                raise ValueError(f"Invalid limit: {limit!r}")
             query_parts.append(f"LIMIT {limit}")
 
         query = " ".join(query_parts)
 
         with self.get_connection() as conn:
-            # Use Polars' read_database method which is efficient
-            df = pl.read_database(query, conn)
+            df = pl.read_database(query, conn, execute_options={"parameters": params})
 
         return df
 
     def get_last_replicated_id(
         self, tracking_table: str, source_table: str
     ) -> int | None:
-        """Get the last replicated ID from a tracking table.
-
-        Args:
-            tracking_table: Name of the table that tracks replication state
-            source_table: Name of the source table being replicated
-
-        Returns:
-            Last replicated ID, or None if no records exist
-        """
+        """Get the last replicated ID from a tracking table."""
+        _validate_identifier(tracking_table, "tracking_table")
         query = f"""
             SELECT last_replicated_id
             FROM {tracking_table}
@@ -134,6 +151,7 @@ class SQLiteResource(dg.ConfigurableResource):
 
     def get_table_info(self, table_name: str) -> list[dict[str, Any]]:
         """Get schema information for a table."""
+        _validate_identifier(table_name, "table name")
         query = f"PRAGMA table_info({table_name})"
         with self.get_connection() as conn:
             cursor = conn.cursor()
@@ -151,15 +169,26 @@ class SQLiteResource(dg.ConfigurableResource):
                 for col in columns
             ]
 
-    def get_row_count(self, table_name: str, where_clause: str | None = None) -> int:
-        """Get the number of rows in a table."""
+    def get_row_count(
+        self,
+        table_name: str,
+        where: tuple[str, tuple[Any, ...]] | None = None,
+    ) -> int:
+        """Get the number of rows in a table.
+
+        ``where`` is an optional ``(sql, params)`` pair with ``?`` placeholders.
+        """
+        _validate_identifier(table_name, "table name")
         query = f"SELECT COUNT(*) FROM {table_name}"
-        if where_clause:
-            query += f" WHERE {where_clause}"
+        params: tuple[Any, ...] = ()
+        if where is not None:
+            where_sql, where_params = where
+            query += f" WHERE {where_sql}"
+            params = tuple(where_params)
 
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            cursor.execute(query)
+            cursor.execute(query, params)
             result = cursor.fetchone()
             return result[0] if result else 0
 

--- a/macro_agents/src/macro_agents/defs/resources/sqlite_resource.py
+++ b/macro_agents/src/macro_agents/defs/resources/sqlite_resource.py
@@ -67,6 +67,13 @@ class SQLiteResource(dg.ConfigurableResource):
         try:
             conn = sqlite3.connect(str(db_path))
             conn.row_factory = sqlite3.Row
+            # Restrict the DB file to the owning user. The default umask can
+            # leave 0644 on shared hosts, which would expose telemetry/user
+            # rows to any local user. chmod is a no-op on Windows.
+            try:
+                os.chmod(db_path, 0o600)
+            except OSError:
+                pass
             yield conn
         finally:
             if conn:

--- a/macro_agents/src/macro_agents/defs/telemetry/telemetry.py
+++ b/macro_agents/src/macro_agents/defs/telemetry/telemetry.py
@@ -93,9 +93,9 @@ def telemetry_events_raw(
         last_id = None
 
     # Build WHERE clause for incremental replication
-    where_clause = None
+    where = None
     if last_id is not None:
-        where_clause = f"id > {last_id}"
+        where = ("id > ?", (last_id,))
         context.log.info(f"Fetching events with id > {last_id}")
     else:
         context.log.info("Fetching all events (first run)")
@@ -104,8 +104,8 @@ def telemetry_events_raw(
     try:
         df = sqlite.read_table_as_polars(
             table_name="telemetry_events",
-            where_clause=where_clause,
-            order_by="id ASC",
+            where=where,
+            order_by=("id", "ASC"),
         )
     except Exception as e:
         context.log.error(f"Failed to read from SQLite: {e}")
@@ -259,7 +259,7 @@ def users_raw(
 
     # Read all users from SQLite
     try:
-        df = sqlite.read_table_as_polars(table_name="users", order_by="id ASC")
+        df = sqlite.read_table_as_polars(table_name="users", order_by=("id", "ASC"))
     except Exception as e:
         context.log.error(f"Failed to read users from SQLite: {e}")
         ensure_table_exists()

--- a/macro_agents/tests/test_resources.py
+++ b/macro_agents/tests/test_resources.py
@@ -23,7 +23,7 @@ class TestMotherDuckResource:
 
         assert resource.environment == "dev"
         assert resource.local_path == "test.duckdb"
-        assert resource.db_connection == "test.duckdb"
+        assert resource._db_connection == "test.duckdb"
 
     def test_initialization_prod_environment(self):
         """Test resource initialization in prod environment."""
@@ -33,7 +33,25 @@ class TestMotherDuckResource:
 
         assert resource.environment == "prod"
         assert resource.md_token == "test_token"
-        assert resource.db_connection == "md:?motherduck_token=test_token"
+        assert resource._db_connection == "md:?motherduck_token=test_token"
+
+    def test_drop_create_does_not_leak_token(self):
+        """drop_create_duck_db_table must not return the connection string."""
+        with tempfile.NamedTemporaryFile(suffix=".duckdb", delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+        try:
+            resource = MotherDuckResource(
+                md_token="secret_token", environment="dev", local_path=tmp_path
+            )
+            result = resource.drop_create_duck_db_table(
+                "leak_check", pl.DataFrame({"id": [1]})
+            )
+            assert "motherduck_token" not in result
+            assert "secret_token" not in result
+            assert result == "leak_check"
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
 
     def test_table_exists(self):
         """Test table existence check."""

--- a/scripts/setup-gcp-vm.sh
+++ b/scripts/setup-gcp-vm.sh
@@ -62,7 +62,7 @@ else
         --boot-disk-type=pd-ssd \
         --image-family=ubuntu-2204-lts \
         --image-project=ubuntu-os-cloud \
-        --scopes=cloud-platform \
+        --scopes=https://www.googleapis.com/auth/devstorage.read_write,https://www.googleapis.com/auth/bigquery,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/cloud-platform.read-only \
         --tags=dagster,http-server \
         --metadata=enable-oslogin=TRUE
 


### PR DESCRIPTION
## Summary

Addresses the security audit findings in one branch (three logical commits).

### Critical
- **MotherDuck token leak** in `drop_create_duck_db_table` return value. Made connection string property private and returned `table_name` instead. No callers used the prior return value.
- **VM scope `cloud-platform`** replaced with a narrow scope list (storage rw, bigquery, logging.write, monitoring.write, cloud-platform.read-only) in both `main.tf` and `setup-gcp-vm.sh`.

### High
- **SQL injection** fixed in `query_sampled_data`, `get_unique_categories`, `SQLiteResource.read_table_as_polars`, and `get_row_count`. Values are now parameterized; identifiers are validated against a strict regex allowlist.
- **NL-to-SQL validator** rewritten on top of `sqlglot` AST checks. The old regex/keyword approach was bypassable via comments, mixed case, and whitespace (`SELECT/**/1; DROP TABLE t`, `DRoP TABLE x`, etc.). Added `sqlglot` to dependencies.
- **Deploy health check** no longer hits the VM's external IP over plain HTTP. Probes `localhost:3000` over SSH instead and stops printing the external IP in workflow logs.
- **GitHub Actions** pinned to commit SHAs (`actions/checkout`, `setup-python`, `cache`; `astral-sh/setup-uv`; `google-github-actions/auth`, `setup-gcloud`). Version tags retained as trailing comments.

### Medium
- Census API error response body truncated to 200 chars in `housing.py`.
- SQLite DB file `chmod 0600` on connect.
- `profiles.yml`: documented the dbt-duckdb constraint that forces the MotherDuck token into the path, with mitigations (log level, `target/` artifact handling, rotation).

### Low
- `docker-compose.yml`: removed personal GitHub owner/repo defaults; vars are now required.
- `nl_query_resource.py`: added `max_calls_per_run` (default 500, env `NL_QUERY_MAX_CALLS`) to bound LLM spend on runaway loops.

### Not addressed in this PR
- Terraform state encryption (med). That's a one-time GCS backend + CMEK + IAM decision rather than a code change. Happy to add a docs block in a follow-up.

## Test plan
- [x] `pytest tests/test_resources.py tests/test_dspy_modules.py` — 71 passed
- [x] Manual SQLValidator bypass cases (comments, mixed case, multi-statement, DDL/DML) — all rejected
- [ ] CI workflow runs on this branch (will trigger on PR open)
- [ ] Manual smoke: `dg dev` still loads the resources without import errors
- [ ] Manual deploy dry-run before merging to confirm the SSH-based health check works

🤖 Generated with [Claude Code](https://claude.com/claude-code)