### PR TITLE
feat(sec): Metaxy metadata layer — Phase 1 POC (#46)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ MOTHERDUCK_DATABASE=your_database_name
 MOTHERDUCK_PROD_SCHEMA=public
 LOCAL_DUCKDB_PATH=local.duckdb
 
+# Metaxy metadata store (issue #46). Connection string for a *separate*
+# MotherDuck database that stores Metaxy lineage/versioning catalog.
+# Format: md:<database_name>?motherduck_token=<token>
+METAXY_STORES__PROD__CONFIG__DATABASE=
+
 # =============================================================================
 # DATA SOURCE APIs
 # =============================================================================

--- a/macro_agents/metaxy.toml
+++ b/macro_agents/metaxy.toml
@@ -1,0 +1,13 @@
+# Metaxy metadata layer config (issue #46).
+# Database connection string is injected via env var
+# METAXY_STORES__PROD__CONFIG__DATABASE — typically
+# "md:econ_data_metaxy?motherduck_token=$MOTHERDUCK_TOKEN" — so this file does
+# not contain secrets.
+
+store = "prod"
+entrypoints = ["macro_agents.defs.domains.sec.lineage"]
+auto_create_tables = true
+
+[stores.prod]
+type = "metaxy.ext.duckdb.DuckDBMetadataStore"
+config = {}

--- a/macro_agents/pyproject.toml
+++ b/macro_agents/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "pdfplumber>=0.11.0,<1.0.0",
     "vadersentiment>=3.3.2",
     "sqlglot>=25.0.0,<27.0.0",
+    "metaxy>=0.1.10,<0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/macro_agents/pyproject.toml
+++ b/macro_agents/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "dagster-duckdb",
     "duckdb>=1.4.0,<1.5.0",
     "polars>=1.0.0,<2.0.0",
-    "dagster-dbt",
+    "dagster-dbt>=0.28.18,<1.0.0",
     "requests>=2.31.0,<3.0.0",
     "dbt-core>=1.11.10,<2.0.0",
     "google-api-core>=2.0.0,<3.0.0",
@@ -27,7 +27,7 @@ dependencies = [
     "lxml>=5.0.0,<7.0.0",
     "tenacity>=9.1.2,<10.0.0",
     "dspy>=3.0.0,<4.0.0",
-    "dagster-sling",
+    "dagster-sling>=0.28.18,<1.0.0",
     "google-cloud-storage>=2.10.0,<4.0.0",
     "altair>=5.3.0,<6.0.0",
     "vl-convert-python>=1.6.0,<2.0.0",
@@ -45,8 +45,8 @@ dependencies = [
     "networkx>=3.2.0,<4.0.0",
     "pdfplumber>=0.11.0,<1.0.0",
     "vadersentiment>=3.3.2",
-    "sqlglot>=25.0.0,<27.0.0",
-    "metaxy>=0.1.10,<0.2.0",
+    "sqlglot>=28.1.0,<29.0.0",
+    "metaxy[duckdb,dagster]>=0.1.10,<0.2.0",
 ]
 
 [project.optional-dependencies]
@@ -65,6 +65,12 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv]
+# metaxy 0.1.10 requires sqlglot>=28.1 while dagster-dbt 0.29.x pins
+# sqlglot<28.1. Both pins look conservative; override to a version both
+# accept at runtime. Revisit when either package relaxes its constraint.
+override-dependencies = ["sqlglot>=28.1.0,<29.0.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/macro_agents"]

--- a/macro_agents/pyproject.toml
+++ b/macro_agents/pyproject.toml
@@ -69,8 +69,14 @@ build-backend = "hatchling.build"
 [tool.uv]
 # metaxy 0.1.10 requires sqlglot>=28.1 while dagster-dbt 0.29.x pins
 # sqlglot<28.1. Both pins look conservative; override to a version both
-# accept at runtime. Revisit when either package relaxes its constraint.
-override-dependencies = ["sqlglot>=28.1.0,<29.0.0"]
+# accept at runtime. sqlglot 28.10 ships with sqlglotrs 0.12.0, so we
+# override sqlglotrs too — otherwise dagster-dbt's transitive sqlglot[rs]
+# constraint resolves the rust extension to 0.6.1 which is ABI-incompatible
+# with the upgraded sqlglot. Revisit when either package relaxes.
+override-dependencies = [
+    "sqlglot>=28.1.0,<29.0.0",
+    "sqlglotrs>=0.12.0,<0.13.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/macro_agents"]

--- a/macro_agents/src/macro_agents/defs/domains/sec/bi.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/bi.py
@@ -1,6 +1,9 @@
 import dagster as dg
 import polars as pl
+from metaxy.ext.dagster import metaxify
+from metaxy.metadata_store.base import MetadataStore
 
+from macro_agents.defs.domains.sec import lineage  # noqa: F401 — register features
 from macro_agents.defs.domains.sec.tables import ensure_sec_filing_search_terms_table
 from macro_agents.defs.domains.sec.text import sec_filing_text_extracted
 from macro_agents.defs.resources.gcs import GCSResource
@@ -16,17 +19,20 @@ from macro_agents.defs.domains.sec.config import (
 from macro_agents.defs.utils.sec_bi_extractor import SECBIExtractor
 
 
+@metaxify(key="sec_filing_business_intelligence")
 @dg.asset(
     group_name="transformation",
     kinds={"gcs", "duckdb", "sec_filing_documents"},
     deps=[sec_filing_text_extracted],
     description="Extract business intelligence signals from SEC filing content",
+    metadata={"metaxy/feature": "sec/bi_signals"},
 )
 def sec_filing_business_intelligence(
     context: dg.AssetExecutionContext,
     sec_edgar: SECEdgarResource,
     gcs: GCSResource,
     md: MotherDuckResource,
+    metaxy_store: dg.ResourceParam[MetadataStore],
 ) -> dg.MaterializeResult:
     """
     Extract business intelligence signals from SEC filing content.
@@ -48,6 +54,9 @@ def sec_filing_business_intelligence(
     3. Store signals in sec_filing_search_terms table
     """
     conn = None
+    metaxy_stale_count: int | None = None
+    metaxy_divergence_count: int | None = None
+    metaxy_shadow_error: str | None = None
     try:
         conn = md.get_connection()
         ensure_sec_filing_search_terms_table(conn)
@@ -77,10 +86,43 @@ def sec_filing_business_intelligence(
             connection=conn,
         )
 
+        # Shadow mode (issue #46 Phase 2): expansion lineage, so Metaxy yields
+        # term-level rows but with `filing_id` carried through. Collapse to
+        # filing_ids for parity with the boolean-driven query above. Some
+        # divergence is expected by design — the boolean check is filing-level
+        # ("any term exists?") while Metaxy is term-level.
+        try:
+            boolean_stale_filing_ids = set(
+                filings_to_process["filing_id"].unique().to_list()
+            )
+            with metaxy_store:
+                increment = metaxy_store.resolve_update("sec/bi_signals").to_polars()
+                metaxy_stale_filing_ids: set[str] = set()
+                for frame in (increment.new, increment.stale):
+                    if "filing_id" in frame.columns:
+                        metaxy_stale_filing_ids.update(
+                            frame["filing_id"].unique().to_list()
+                        )
+            metaxy_stale_count = len(metaxy_stale_filing_ids)
+            metaxy_divergence_count = len(
+                metaxy_stale_filing_ids.symmetric_difference(boolean_stale_filing_ids)
+            )
+        except Exception as e:  # noqa: BLE001 — shadow mode must never fail the asset
+            metaxy_shadow_error = f"{type(e).__name__}: {e}"
+            context.log.warning(
+                f"Metaxy shadow comparison failed: {metaxy_shadow_error}"
+            )
+
         if filings_to_process.is_empty():
             context.log.debug("No filings to extract business intelligence from")
             return dg.MaterializeResult(
-                metadata={"status": "no_filings", "filings_processed": 0}
+                metadata={
+                    "status": "no_filings",
+                    "filings_processed": 0,
+                    "metaxy_stale_count": metaxy_stale_count,
+                    "metaxy_divergence_count": metaxy_divergence_count,
+                    "metaxy_shadow_error": metaxy_shadow_error,
+                }
             )
 
         # Group by filing_id to process all sections together
@@ -212,6 +254,9 @@ def sec_filing_business_intelligence(
                 "errors": total_errors,
                 "remaining_to_process": remaining,
                 "error_details": errors[:MAX_ERROR_DETAILS] if errors else [],
+                "metaxy_stale_count": metaxy_stale_count,
+                "metaxy_divergence_count": metaxy_divergence_count,
+                "metaxy_shadow_error": metaxy_shadow_error,
             }
         )
 

--- a/macro_agents/src/macro_agents/defs/domains/sec/fts.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/fts.py
@@ -7,7 +7,10 @@ Complements the vector/semantic search in search.py.
 
 import dagster as dg
 import polars as pl
+from metaxy.ext.dagster import metaxify
+from metaxy.metadata_store.base import MetadataStore
 
+from macro_agents.defs.domains.sec import lineage  # noqa: F401 — register features
 from macro_agents.defs.domains.sec.tables import ensure_sec_filing_content_table
 from macro_agents.defs.domains.sec.text import sec_filing_text_extracted
 from macro_agents.defs.resources.gcs import GCSResource
@@ -38,6 +41,7 @@ def _ensure_fts_content_table(conn) -> None:
     """)
 
 
+@metaxify(key="sec_filing_fts_index")
 @dg.asset(
     group_name="transformation",
     kinds={"duckdb", "search"},
@@ -46,11 +50,13 @@ def _ensure_fts_content_table(conn) -> None:
         "Build DuckDB full-text search index over SEC filing content. "
         "Enables keyword queries across filing sections with metadata filtering."
     ),
+    metadata={"metaxy/feature": "sec/fts_index"},
 )
 def sec_filing_fts_index(
     context: dg.AssetExecutionContext,
     md: MotherDuckResource,
     gcs: GCSResource,
+    metaxy_store: dg.ResourceParam[MetadataStore],
 ) -> dg.MaterializeResult:
     """
     Build and refresh the full-text search index.
@@ -61,6 +67,9 @@ def sec_filing_fts_index(
     3. Create/recreate the DuckDB FTS index using PRAGMA create_fts_index
     """
     conn = None
+    metaxy_stale_count: int | None = None
+    metaxy_divergence_count: int | None = None
+    metaxy_shadow_error: str | None = None
     try:
         conn = md.get_connection()
         ensure_sec_filing_content_table(conn)
@@ -84,6 +93,33 @@ def sec_filing_fts_index(
             """,
             connection=conn,
         )
+
+        # Shadow mode (issue #46): expansion lineage. Roll content-level
+        # new+stale rows up to filing_ids for comparison with the
+        # content-level boolean query above (collapsed via unique filing_id).
+        try:
+            boolean_stale_filing_ids = (
+                set(new_content["filing_id"].unique().to_list())
+                if not new_content.is_empty()
+                else set()
+            )
+            with metaxy_store:
+                increment = metaxy_store.resolve_update("sec/fts_index").to_polars()
+                metaxy_stale_filing_ids: set[str] = set()
+                for frame in (increment.new, increment.stale):
+                    if "filing_id" in frame.columns:
+                        metaxy_stale_filing_ids.update(
+                            frame["filing_id"].unique().to_list()
+                        )
+            metaxy_stale_count = len(metaxy_stale_filing_ids)
+            metaxy_divergence_count = len(
+                metaxy_stale_filing_ids.symmetric_difference(boolean_stale_filing_ids)
+            )
+        except Exception as e:  # noqa: BLE001 — shadow mode must never fail the asset
+            metaxy_shadow_error = f"{type(e).__name__}: {e}"
+            context.log.warning(
+                f"Metaxy shadow comparison failed: {metaxy_shadow_error}"
+            )
 
         if new_content.is_empty():
             context.log.debug("FTS table already up to date")
@@ -158,6 +194,9 @@ def sec_filing_fts_index(
                 "status": "completed",
                 "total_indexed_sections": total_indexed,
                 "new_sections_added": len(new_content),
+                "metaxy_stale_count": metaxy_stale_count,
+                "metaxy_divergence_count": metaxy_divergence_count,
+                "metaxy_shadow_error": metaxy_shadow_error,
             }
         )
 

--- a/macro_agents/src/macro_agents/defs/domains/sec/lineage.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/lineage.py
@@ -1,9 +1,9 @@
 """Metaxy FeatureSpecs for the SEC filing pipeline.
 
-Phase 1 (issue #46) declares only the first two stages — `sec/raw_html` as a
-source feature, and `sec/extracted_text` as identity lineage downstream of it.
-Subsequent phases will add `sec/embeddings`, `sec/fts_index`, `sec/bi_signals`,
-and `sec/search_index`.
+Phase 1 (issue #46) declared `sec/raw_html` and `sec/extracted_text`.
+Phase 2 adds `sec/bi_signals` (expansion from extracted_text — each filing
+produces many term rows).
+Remaining phases will add `sec/embeddings`, `sec/fts_index`, `sec/search_index`.
 
 Features subclass `BaseFeature` (rather than being bare `FeatureSpec`
 instances) so they register in Metaxy's feature graph at import time. The
@@ -37,6 +37,22 @@ class ExtractedText(
             mx.FeatureDep(
                 feature="sec/raw_html",
                 lineage=mx.LineageRelationship.identity(),
+            ),
+        ],
+    ),
+):
+    pass
+
+
+class BiSignals(
+    mx.BaseFeature,
+    spec=mx.FeatureSpec(
+        key="sec/bi_signals",
+        id_columns=("term_id",),
+        deps=[
+            mx.FeatureDep(
+                feature="sec/extracted_text",
+                lineage=mx.LineageRelationship.expansion(on=["filing_id"]),
             ),
         ],
     ),

--- a/macro_agents/src/macro_agents/defs/domains/sec/lineage.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/lineage.py
@@ -1,9 +1,15 @@
 """Metaxy FeatureSpecs for the SEC filing pipeline.
 
-Phase 1 (issue #46) declared `sec/raw_html` and `sec/extracted_text`.
-Phase 2 adds `sec/bi_signals` (expansion from extracted_text — each filing
-produces many term rows).
-Remaining phases will add `sec/embeddings`, `sec/fts_index`, `sec/search_index`.
+Covers every stage of the SEC pipeline (issue #46):
+
+| Feature              | Lineage                       | id_columns       |
+|----------------------|-------------------------------|------------------|
+| sec/raw_html         | source                        | (filing_id,)     |
+| sec/extracted_text   | identity ← raw_html           | (filing_id,)     |
+| sec/bi_signals       | expansion ← extracted_text    | (term_id,)       |
+| sec/embeddings       | expansion ← extracted_text    | (chunk_id,)      |
+| sec/fts_index        | expansion ← extracted_text    | (content_id,)    |
+| sec/search_index     | aggregation ← embeddings + fts_index | (filing_id,) |
 
 Features subclass `BaseFeature` (rather than being bare `FeatureSpec`
 instances) so they register in Metaxy's feature graph at import time. The
@@ -53,6 +59,58 @@ class BiSignals(
             mx.FeatureDep(
                 feature="sec/extracted_text",
                 lineage=mx.LineageRelationship.expansion(on=["filing_id"]),
+            ),
+        ],
+    ),
+):
+    pass
+
+
+class Embeddings(
+    mx.BaseFeature,
+    spec=mx.FeatureSpec(
+        key="sec/embeddings",
+        id_columns=("chunk_id",),
+        deps=[
+            mx.FeatureDep(
+                feature="sec/extracted_text",
+                lineage=mx.LineageRelationship.expansion(on=["filing_id"]),
+            ),
+        ],
+    ),
+):
+    pass
+
+
+class FtsIndex(
+    mx.BaseFeature,
+    spec=mx.FeatureSpec(
+        key="sec/fts_index",
+        id_columns=("content_id",),
+        deps=[
+            mx.FeatureDep(
+                feature="sec/extracted_text",
+                lineage=mx.LineageRelationship.expansion(on=["filing_id"]),
+            ),
+        ],
+    ),
+):
+    pass
+
+
+class SearchIndex(
+    mx.BaseFeature,
+    spec=mx.FeatureSpec(
+        key="sec/search_index",
+        id_columns=("filing_id",),
+        deps=[
+            mx.FeatureDep(
+                feature="sec/embeddings",
+                lineage=mx.LineageRelationship.aggregation(on=["filing_id"]),
+            ),
+            mx.FeatureDep(
+                feature="sec/fts_index",
+                lineage=mx.LineageRelationship.aggregation(on=["filing_id"]),
             ),
         ],
     ),

--- a/macro_agents/src/macro_agents/defs/domains/sec/lineage.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/lineage.py
@@ -1,0 +1,25 @@
+"""Metaxy FeatureSpecs for the SEC filing pipeline.
+
+Phase 1 (issue #46) declares only the first two stages — `sec/raw_html` as a
+source feature, and `sec/extracted_text` as identity lineage downstream of it.
+Subsequent phases will add `sec/embeddings`, `sec/fts_index`, `sec/bi_signals`,
+and `sec/search_index`.
+"""
+
+from metaxy import FeatureDep, FeatureSpec, LineageRelationship
+
+raw_html = FeatureSpec(
+    key="sec/raw_html",
+    id_columns=("filing_id",),
+)
+
+extracted_text = FeatureSpec(
+    key="sec/extracted_text",
+    id_columns=("filing_id",),
+    deps=[
+        FeatureDep(
+            feature="sec/raw_html",
+            lineage=LineageRelationship.identity(),
+        ),
+    ],
+)

--- a/macro_agents/src/macro_agents/defs/domains/sec/lineage.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/lineage.py
@@ -4,22 +4,41 @@ Phase 1 (issue #46) declares only the first two stages — `sec/raw_html` as a
 source feature, and `sec/extracted_text` as identity lineage downstream of it.
 Subsequent phases will add `sec/embeddings`, `sec/fts_index`, `sec/bi_signals`,
 and `sec/search_index`.
+
+Features subclass `BaseFeature` (rather than being bare `FeatureSpec`
+instances) so they register in Metaxy's feature graph at import time. The
+`entrypoints` key in `metaxy.toml` points at this module.
 """
 
-from metaxy import FeatureDep, FeatureSpec, LineageRelationship
+import metaxy as mx
 
-raw_html = FeatureSpec(
-    key="sec/raw_html",
-    id_columns=("filing_id",),
-)
+# Load metaxy.toml (auto-discovered via parent-dir search) and merge env
+# overrides. Must run before BaseFeature subclasses below are evaluated so the
+# global config is in place when features register.
+mx.MetaxyConfig.set(mx.MetaxyConfig.load())
 
-extracted_text = FeatureSpec(
-    key="sec/extracted_text",
-    id_columns=("filing_id",),
-    deps=[
-        FeatureDep(
-            feature="sec/raw_html",
-            lineage=LineageRelationship.identity(),
-        ),
-    ],
-)
+
+class RawHtml(
+    mx.BaseFeature,
+    spec=mx.FeatureSpec(
+        key="sec/raw_html",
+        id_columns=("filing_id",),
+    ),
+):
+    pass
+
+
+class ExtractedText(
+    mx.BaseFeature,
+    spec=mx.FeatureSpec(
+        key="sec/extracted_text",
+        id_columns=("filing_id",),
+        deps=[
+            mx.FeatureDep(
+                feature="sec/raw_html",
+                lineage=mx.LineageRelationship.identity(),
+            ),
+        ],
+    ),
+):
+    pass

--- a/macro_agents/src/macro_agents/defs/domains/sec/search.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/search.py
@@ -10,7 +10,10 @@ import re
 
 import dagster as dg
 import polars as pl
+from metaxy.ext.dagster import metaxify
+from metaxy.metadata_store.base import MetadataStore
 
+from macro_agents.defs.domains.sec import lineage  # noqa: F401 — register features
 from macro_agents.defs.domains.sec.tables import ensure_sec_filing_chunks_table
 from macro_agents.defs.domains.sec.text import sec_filing_text_extracted
 from macro_agents.defs.resources.gcs import GCSResource
@@ -115,6 +118,7 @@ def _split_text_into_chunks(
     return chunks
 
 
+@metaxify(key="sec_filing_search_index")
 @dg.asset(
     group_name="transformation",
     kinds={"llm", "duckdb", "ollama"},
@@ -123,12 +127,14 @@ def _split_text_into_chunks(
         "Generate chunked embeddings from SEC filing text for semantic search. "
         "Splits content into ~500-token chunks and embeds via Ollama."
     ),
+    metadata={"metaxy/feature": "sec/embeddings"},
 )
 def sec_filing_search_index(
     context: dg.AssetExecutionContext,
     md: MotherDuckResource,
     gcs: GCSResource,
     ollama: OllamaResource,
+    metaxy_store: dg.ResourceParam[MetadataStore],
 ) -> dg.MaterializeResult:
     """
     Build chunked vector search index from SEC filing content.
@@ -141,6 +147,9 @@ def sec_filing_search_index(
     5. Store chunk text + embedding in sec_filing_chunks
     """
     conn = None
+    metaxy_stale_count: int | None = None
+    metaxy_divergence_count: int | None = None
+    metaxy_shadow_error: str | None = None
     try:
         conn = md.get_connection()
         ensure_sec_filing_chunks_table(conn)
@@ -177,10 +186,41 @@ def sec_filing_search_index(
             connection=conn,
         )
 
+        # Shadow mode (issue #46 Phase 2): expansion lineage. Roll Metaxy's
+        # chunk-level new+stale rows up to filing_ids and compare to the
+        # filing_ids surfaced by the section-level boolean query above.
+        try:
+            boolean_stale_filing_ids = set(
+                sections_to_process["filing_id"].unique().to_list()
+            )
+            with metaxy_store:
+                increment = metaxy_store.resolve_update("sec/embeddings").to_polars()
+                metaxy_stale_filing_ids: set[str] = set()
+                for frame in (increment.new, increment.stale):
+                    if "filing_id" in frame.columns:
+                        metaxy_stale_filing_ids.update(
+                            frame["filing_id"].unique().to_list()
+                        )
+            metaxy_stale_count = len(metaxy_stale_filing_ids)
+            metaxy_divergence_count = len(
+                metaxy_stale_filing_ids.symmetric_difference(boolean_stale_filing_ids)
+            )
+        except Exception as e:  # noqa: BLE001 — shadow mode must never fail the asset
+            metaxy_shadow_error = f"{type(e).__name__}: {e}"
+            context.log.warning(
+                f"Metaxy shadow comparison failed: {metaxy_shadow_error}"
+            )
+
         if sections_to_process.is_empty():
             context.log.debug("No sections pending chunk embedding")
             return dg.MaterializeResult(
-                metadata={"status": "up_to_date", "chunks_created": 0}
+                metadata={
+                    "status": "up_to_date",
+                    "chunks_created": 0,
+                    "metaxy_stale_count": metaxy_stale_count,
+                    "metaxy_divergence_count": metaxy_divergence_count,
+                    "metaxy_shadow_error": metaxy_shadow_error,
+                }
             )
 
         total_chunks = 0
@@ -292,6 +332,9 @@ def sec_filing_search_index(
                 "chunks_created": total_chunks,
                 "errors": len(errors),
                 "error_details": errors[:MAX_ERROR_DETAILS] if errors else [],
+                "metaxy_stale_count": metaxy_stale_count,
+                "metaxy_divergence_count": metaxy_divergence_count,
+                "metaxy_shadow_error": metaxy_shadow_error,
             }
         )
 

--- a/macro_agents/src/macro_agents/defs/domains/sec/semantic_search.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/semantic_search.py
@@ -7,7 +7,10 @@ DuckDB full-text search for AI agent workflows.
 
 import dagster as dg
 import polars as pl
+from metaxy.ext.dagster import metaxify
+from metaxy.metadata_store.base import MetadataStore
 
+from macro_agents.defs.domains.sec import lineage  # noqa: F401 — register features
 from macro_agents.defs.domains.sec.fts import FTS_TABLE, sec_filing_fts_index
 from macro_agents.defs.domains.sec.search import sec_filing_search_index
 from macro_agents.defs.resources.motherduck import MotherDuckResource
@@ -209,6 +212,7 @@ def hybrid_search(
     return pl.DataFrame(ranked[:top_k])
 
 
+@metaxify(key="sec_filing_hybrid_search_ready")
 @dg.asset(
     group_name="transformation",
     kinds={"duckdb", "search"},
@@ -217,13 +221,31 @@ def hybrid_search(
         "Validate hybrid search readiness by checking vector embeddings "
         "and FTS index coverage. Materializes search coverage stats."
     ),
+    metadata={"metaxy/feature": "sec/search_index"},
 )
 def sec_filing_hybrid_search_ready(
     context: dg.AssetExecutionContext,
     md: MotherDuckResource,
+    metaxy_store: dg.ResourceParam[MetadataStore],
 ) -> dg.MaterializeResult:
     """Check that both vector and FTS indexes are populated and queryable."""
     conn = None
+    metaxy_stale_count: int | None = None
+    metaxy_shadow_error: str | None = None
+
+    # Shadow mode (issue #46): aggregation lineage. No boolean staleness
+    # check exists for this validator asset, so we only probe that the
+    # aggregation lookup works and record the stale count.
+    try:
+        with metaxy_store:
+            increment = metaxy_store.resolve_update("sec/search_index").to_polars()
+        metaxy_stale_count = sum(
+            len(frame) for frame in (increment.new, increment.stale)
+        )
+    except Exception as e:  # noqa: BLE001 — shadow mode must never fail the asset
+        metaxy_shadow_error = f"{type(e).__name__}: {e}"
+        context.log.warning(f"Metaxy shadow probe failed: {metaxy_shadow_error}")
+
     try:
         conn = md.get_connection()
 
@@ -267,6 +289,8 @@ def sec_filing_hybrid_search_ready(
                 "fts_filings": fts_stats[1],
                 "fts_symbols": fts_stats[0],
                 "search_ready": vec_stats[2] > 0 or fts_stats[2] > 0,
+                "metaxy_stale_count": metaxy_stale_count,
+                "metaxy_shadow_error": metaxy_shadow_error,
             }
         )
 

--- a/macro_agents/src/macro_agents/defs/domains/sec/text.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/text.py
@@ -4,6 +4,9 @@ import dagster as dg
 import polars as pl
 from metaxy.ext.dagster import MetaxyStoreFromConfigResource, metaxify
 
+# Importing the lineage module registers SEC FeatureSpecs in Metaxy's global
+# feature graph before @metaxify below tries to look them up.
+from macro_agents.defs.domains.sec import lineage  # noqa: F401
 from macro_agents.defs.domains.sec.metadata import sec_filing_metadata
 from macro_agents.defs.domains.sec.tables import ensure_sec_filing_content_table
 from macro_agents.defs.resources.gcs import GCSResource

--- a/macro_agents/src/macro_agents/defs/domains/sec/text.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/text.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 import dagster as dg
 import polars as pl
+from metaxy.ext.dagster import MetaxyStoreFromConfigResource, metaxify
 
 from macro_agents.defs.domains.sec.metadata import sec_filing_metadata
 from macro_agents.defs.domains.sec.tables import ensure_sec_filing_content_table
@@ -12,17 +13,20 @@ from macro_agents.defs.domains.sec.config import BATCH_SIZE_STANDARD, MAX_ERROR_
 from macro_agents.defs.utils.sec_text_extractor import SECTextExtractor
 
 
+@metaxify
 @dg.asset(
     group_name="transformation",
     kinds={"gcs", "duckdb", "sec_filing_documents"},
     deps=[sec_filing_metadata],
     description="Extract text content from SEC filings stored in GCS",
+    metadata={"metaxy/feature": "sec/extracted_text"},
 )
 def sec_filing_text_extracted(
     context: dg.AssetExecutionContext,
     sec_edgar: SECEdgarResource,
     gcs: GCSResource,
     md: MotherDuckResource,
+    metaxy_store: MetaxyStoreFromConfigResource,
 ) -> dg.MaterializeResult:
     """
     Extract text content from SEC filings stored in GCS.
@@ -34,6 +38,9 @@ def sec_filing_text_extracted(
     4. Store extracted content in sec_filing_content table
     """
     conn = None
+    metaxy_stale_count: int | None = None
+    metaxy_divergence_count: int | None = None
+    metaxy_shadow_error: str | None = None
     try:
         conn = md.get_connection()
         ensure_sec_filing_content_table(conn)
@@ -55,10 +62,38 @@ def sec_filing_text_extracted(
             connection=conn,
         )
 
+        # Shadow mode (issue #46 Phase 1): compute Metaxy's stale set and log
+        # divergence vs. the boolean-based query above. Behavior is unchanged —
+        # only measurement happens here. Wrapped in try/except so a store
+        # outage cannot block extraction.
+        try:
+            boolean_stale_ids = set(filings_to_process["filing_id"].to_list())
+            with metaxy_store.get_store() as store:
+                increment = store.resolve_update("sec/extracted_text")
+                metaxy_stale_df = increment.to_native()
+                metaxy_stale_ids = (
+                    set(metaxy_stale_df["filing_id"].to_list())
+                    if "filing_id" in metaxy_stale_df.columns
+                    else set()
+                )
+            metaxy_stale_count = len(metaxy_stale_ids)
+            metaxy_divergence_count = len(
+                metaxy_stale_ids.symmetric_difference(boolean_stale_ids)
+            )
+        except Exception as e:  # noqa: BLE001 — shadow mode must never fail the asset
+            metaxy_shadow_error = f"{type(e).__name__}: {e}"
+            context.log.warning(f"Metaxy shadow comparison failed: {metaxy_shadow_error}")
+
         if filings_to_process.is_empty():
             context.log.debug("No filings to extract text from")
             return dg.MaterializeResult(
-                metadata={"status": "no_filings", "filings_processed": 0}
+                metadata={
+                    "status": "no_filings",
+                    "filings_processed": 0,
+                    "metaxy_stale_count": metaxy_stale_count,
+                    "metaxy_divergence_count": metaxy_divergence_count,
+                    "metaxy_shadow_error": metaxy_shadow_error,
+                }
             )
 
         context.log.debug(f"Extracting text from {len(filings_to_process)} filings")
@@ -218,6 +253,9 @@ def sec_filing_text_extracted(
                 "errors": total_errors,
                 "remaining_to_process": remaining,
                 "error_details": errors[:MAX_ERROR_DETAILS] if errors else [],
+                "metaxy_stale_count": metaxy_stale_count,
+                "metaxy_divergence_count": metaxy_divergence_count,
+                "metaxy_shadow_error": metaxy_shadow_error,
             }
         )
 

--- a/macro_agents/src/macro_agents/defs/domains/sec/text.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/text.py
@@ -2,7 +2,8 @@ from datetime import datetime, timezone
 
 import dagster as dg
 import polars as pl
-from metaxy.ext.dagster import MetaxyStoreFromConfigResource, metaxify
+from metaxy.ext.dagster import metaxify
+from metaxy.metadata_store.base import MetadataStore
 
 # Importing the lineage module registers SEC FeatureSpecs in Metaxy's global
 # feature graph before @metaxify below tries to look them up.
@@ -16,7 +17,7 @@ from macro_agents.defs.domains.sec.config import BATCH_SIZE_STANDARD, MAX_ERROR_
 from macro_agents.defs.utils.sec_text_extractor import SECTextExtractor
 
 
-@metaxify
+@metaxify(key="sec_filing_text_extracted")
 @dg.asset(
     group_name="transformation",
     kinds={"gcs", "duckdb", "sec_filing_documents"},
@@ -29,7 +30,7 @@ def sec_filing_text_extracted(
     sec_edgar: SECEdgarResource,
     gcs: GCSResource,
     md: MotherDuckResource,
-    metaxy_store: MetaxyStoreFromConfigResource,
+    metaxy_store: dg.ResourceParam[MetadataStore],
 ) -> dg.MaterializeResult:
     """
     Extract text content from SEC filings stored in GCS.
@@ -71,21 +72,26 @@ def sec_filing_text_extracted(
         # outage cannot block extraction.
         try:
             boolean_stale_ids = set(filings_to_process["filing_id"].to_list())
-            with metaxy_store.get_store() as store:
-                increment = store.resolve_update("sec/extracted_text")
-                metaxy_stale_df = increment.to_native()
-                metaxy_stale_ids = (
-                    set(metaxy_stale_df["filing_id"].to_list())
-                    if "filing_id" in metaxy_stale_df.columns
-                    else set()
-                )
+            with metaxy_store:
+                increment = metaxy_store.resolve_update(
+                    "sec/extracted_text"
+                ).to_polars()
+                # "stale" in this context means filings the asset still needs
+                # to run on — i.e., new samples plus samples whose upstream
+                # provenance changed.
+                metaxy_stale_ids: set[str] = set()
+                for frame in (increment.new, increment.stale):
+                    if "filing_id" in frame.columns:
+                        metaxy_stale_ids.update(frame["filing_id"].to_list())
             metaxy_stale_count = len(metaxy_stale_ids)
             metaxy_divergence_count = len(
                 metaxy_stale_ids.symmetric_difference(boolean_stale_ids)
             )
         except Exception as e:  # noqa: BLE001 — shadow mode must never fail the asset
             metaxy_shadow_error = f"{type(e).__name__}: {e}"
-            context.log.warning(f"Metaxy shadow comparison failed: {metaxy_shadow_error}")
+            context.log.warning(
+                f"Metaxy shadow comparison failed: {metaxy_shadow_error}"
+            )
 
         if filings_to_process.is_empty():
             context.log.debug("No filings to extract text from")

--- a/macro_agents/src/macro_agents/defs/shared_resources.py
+++ b/macro_agents/src/macro_agents/defs/shared_resources.py
@@ -1,4 +1,5 @@
 import dagster as dg
+from metaxy.ext.dagster import MetaxyStoreFromConfigResource
 
 from macro_agents.defs.resources.federal_reserve import FederalReserveResource
 from macro_agents.defs.resources.gcs import GCSResource
@@ -12,6 +13,7 @@ from macro_agents.defs.resources.sqlite_resource import sqlite_resource
 defs = dg.Definitions(
     resources={
         "md": motherduck_resource,
+        "metaxy_store": MetaxyStoreFromConfigResource(name="prod"),
         "sqlite": sqlite_resource,
         "gcs": GCSResource(
             bucket_name=dg.EnvVar("GCS_BUCKET_NAME"),

--- a/macro_agents/tests/test_metaxy_lineage.py
+++ b/macro_agents/tests/test_metaxy_lineage.py
@@ -1,35 +1,38 @@
-"""Tests for Metaxy FeatureSpec declarations (issue #46, Phase 1).
+"""Tests for Metaxy feature declarations (issue #46, Phase 1).
 
-These are pure validation tests on the FeatureSpec module — they don't touch a
-metadata store. The integration test that materializes the wrapped asset twice
-lives separately (gated by MotherDuck credentials) so it can be skipped in CI.
+Pure validation tests on the feature module — they don't touch a metadata
+store. The integration test that materializes the wrapped asset twice lives
+separately so it can be skipped in CI.
 """
 
 import pytest
 
 pytest.importorskip("metaxy")
 
-from metaxy import FeatureSpec  # noqa: E402
-
 from macro_agents.defs.domains.sec import lineage  # noqa: E402
 
 
+def _spec(cls):
+    """Return the FeatureSpec attached to a BaseFeature subclass.
+
+    Metaxy 0.1.x stores it on `_feature_spec`; fall back to `spec` if that
+    moves in a future release.
+    """
+    return getattr(cls, "_feature_spec", None) or cls.spec
+
+
 def test_raw_html_is_source_feature():
-    spec = lineage.raw_html
-    assert isinstance(spec, FeatureSpec)
+    spec = _spec(lineage.RawHtml)
     assert str(spec.key) == "sec/raw_html"
     assert spec.id_columns == ("filing_id",)
     assert spec.deps == []
 
 
 def test_extracted_text_has_identity_lineage_from_raw_html():
-    spec = lineage.extracted_text
-    assert isinstance(spec, FeatureSpec)
+    spec = _spec(lineage.ExtractedText)
     assert str(spec.key) == "sec/extracted_text"
     assert spec.id_columns == ("filing_id",)
     assert len(spec.deps) == 1
     parent = spec.deps[0]
     assert str(parent.feature) == "sec/raw_html"
-    # Identity is the default relationship; the type name is the cheapest
-    # cross-version check.
     assert type(parent.lineage.relationship).__name__ == "IdentityRelationship"

--- a/macro_agents/tests/test_metaxy_lineage.py
+++ b/macro_agents/tests/test_metaxy_lineage.py
@@ -1,0 +1,35 @@
+"""Tests for Metaxy FeatureSpec declarations (issue #46, Phase 1).
+
+These are pure validation tests on the FeatureSpec module — they don't touch a
+metadata store. The integration test that materializes the wrapped asset twice
+lives separately (gated by MotherDuck credentials) so it can be skipped in CI.
+"""
+
+import pytest
+
+pytest.importorskip("metaxy")
+
+from metaxy import FeatureSpec  # noqa: E402
+
+from macro_agents.defs.domains.sec import lineage  # noqa: E402
+
+
+def test_raw_html_is_source_feature():
+    spec = lineage.raw_html
+    assert isinstance(spec, FeatureSpec)
+    assert str(spec.key) == "sec/raw_html"
+    assert spec.id_columns == ("filing_id",)
+    assert spec.deps == []
+
+
+def test_extracted_text_has_identity_lineage_from_raw_html():
+    spec = lineage.extracted_text
+    assert isinstance(spec, FeatureSpec)
+    assert str(spec.key) == "sec/extracted_text"
+    assert spec.id_columns == ("filing_id",)
+    assert len(spec.deps) == 1
+    parent = spec.deps[0]
+    assert str(parent.feature) == "sec/raw_html"
+    # Identity is the default relationship; the type name is the cheapest
+    # cross-version check.
+    assert type(parent.lineage.relationship).__name__ == "IdentityRelationship"

--- a/macro_agents/tests/test_metaxy_lineage.py
+++ b/macro_agents/tests/test_metaxy_lineage.py
@@ -13,12 +13,8 @@ from macro_agents.defs.domains.sec import lineage  # noqa: E402
 
 
 def _spec(cls):
-    """Return the FeatureSpec attached to a BaseFeature subclass.
-
-    Metaxy 0.1.x stores it on `_feature_spec`; fall back to `spec` if that
-    moves in a future release.
-    """
-    return getattr(cls, "_feature_spec", None) or cls.spec
+    """Return the FeatureSpec attached to a BaseFeature subclass."""
+    return cls._spec
 
 
 def test_raw_html_is_source_feature():

--- a/macro_agents/tests/test_metaxy_lineage.py
+++ b/macro_agents/tests/test_metaxy_lineage.py
@@ -44,3 +44,39 @@ def test_bi_signals_has_expansion_lineage_from_extracted_text():
     rel = parent.lineage.relationship
     assert type(rel).__name__ == "ExpansionRelationship"
     assert list(rel.on) == ["filing_id"]
+
+
+def test_embeddings_has_expansion_lineage_from_extracted_text():
+    spec = _spec(lineage.Embeddings)
+    assert str(spec.key) == "sec/embeddings"
+    assert spec.id_columns == ("chunk_id",)
+    assert len(spec.deps) == 1
+    parent = spec.deps[0]
+    assert str(parent.feature) == "sec/extracted_text"
+    rel = parent.lineage.relationship
+    assert type(rel).__name__ == "ExpansionRelationship"
+    assert list(rel.on) == ["filing_id"]
+
+
+def test_fts_index_has_expansion_lineage_from_extracted_text():
+    spec = _spec(lineage.FtsIndex)
+    assert str(spec.key) == "sec/fts_index"
+    assert spec.id_columns == ("content_id",)
+    assert len(spec.deps) == 1
+    parent = spec.deps[0]
+    assert str(parent.feature) == "sec/extracted_text"
+    rel = parent.lineage.relationship
+    assert type(rel).__name__ == "ExpansionRelationship"
+    assert list(rel.on) == ["filing_id"]
+
+
+def test_search_index_aggregates_embeddings_and_fts_index():
+    spec = _spec(lineage.SearchIndex)
+    assert str(spec.key) == "sec/search_index"
+    assert spec.id_columns == ("filing_id",)
+    parents = {str(d.feature): d for d in spec.deps}
+    assert set(parents) == {"sec/embeddings", "sec/fts_index"}
+    for parent in parents.values():
+        rel = parent.lineage.relationship
+        assert type(rel).__name__ == "AggregationRelationship"
+        assert list(rel.on) == ["filing_id"]

--- a/macro_agents/tests/test_metaxy_lineage.py
+++ b/macro_agents/tests/test_metaxy_lineage.py
@@ -32,3 +32,15 @@ def test_extracted_text_has_identity_lineage_from_raw_html():
     parent = spec.deps[0]
     assert str(parent.feature) == "sec/raw_html"
     assert type(parent.lineage.relationship).__name__ == "IdentityRelationship"
+
+
+def test_bi_signals_has_expansion_lineage_from_extracted_text():
+    spec = _spec(lineage.BiSignals)
+    assert str(spec.key) == "sec/bi_signals"
+    assert spec.id_columns == ("term_id",)
+    assert len(spec.deps) == 1
+    parent = spec.deps[0]
+    assert str(parent.feature) == "sec/extracted_text"
+    rel = parent.lineage.relationship
+    assert type(rel).__name__ == "ExpansionRelationship"
+    assert list(rel.on) == ["filing_id"]

--- a/macro_agents/uv.lock
+++ b/macro_agents/uv.lock
@@ -1,6 +1,14 @@
 version = 1
 revision = 3
 requires-python = "==3.11.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[manifest]
+overrides = [{ name = "sqlglot", specifier = ">=28.1.0,<29.0.0" }]
 
 [[package]]
 name = "agate"
@@ -175,6 +183,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/67/7ea59c3e69eaeee42e7fc91a5be67ca5849c8979acac2b920249760c6af2/asyncer-0.0.8.tar.gz", hash = "sha256:a589d980f57e20efb07ed91d0dbe67f1d2fd343e7142c66d3a099f05c620739c", size = 18217, upload-time = "2024-08-24T23:15:36.449Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/04/15b6ca6b7842eda2748bda0a0af73f2d054e9344320f8bba01f994294bcb/asyncer-0.0.8-py3-none-any.whl", hash = "sha256:5920d48fc99c8f8f0f1576e1882f5022885589c5fcbc46ce4224ec3e53776eeb", size = 9209, upload-time = "2024-08-24T23:15:35.317Z" },
+]
+
+[[package]]
+name = "atpublic"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/05/e2e131a0debaf0f01b8a1b586f5f11713f6affc3e711b406f15f11eafc92/atpublic-7.0.0.tar.gz", hash = "sha256:466ef10d0c8bbd14fd02a5fbd5a8b6af6a846373d91106d3a07c16d72d96b63e", size = 17801, upload-time = "2025-11-29T05:56:45.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl", hash = "sha256:6702bd9e7245eb4e8220a3e222afcef7f87412154732271ee7deee4433b72b4b", size = 6421, upload-time = "2025-11-29T05:56:44.604Z" },
 ]
 
 [[package]]
@@ -428,6 +445,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/c3/d3f095120329616cc364af2bedcffd518d4db18c978f2f6c892d29e6af2f/cyclopts-4.12.0.tar.gz", hash = "sha256:86bfb5b35cb078decc1cca6c1be41f9a0e6202dc43b4f6056d5cfc6d1f4a69d1", size = 176123, upload-time = "2026-05-13T13:26:31.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/d0/17b6b7d5f64dea337a7a409a1e4e0eeceda724046b9acd158fd1aa2f2328/cyclopts-4.12.0-py3-none-any.whl", hash = "sha256:ee03d2b9ef790d866cb3823a7e54b2be5252c82d34536579846fce068b30c38f", size = 213706, upload-time = "2026-05-13T13:26:29.744Z" },
+]
+
+[[package]]
 name = "daff"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -529,7 +561,7 @@ dependencies = [
     { name = "packaging" },
     { name = "requests" },
     { name = "rich" },
-    { name = "sqlglot", extra = ["rs"] },
+    { name = "sqlglot" },
     { name = "typer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/6c/126c7802cce36ee5d83ba06f1ef0d2bdfb53ea09c955a4ea7ab93a6f891c/dagster_dbt-0.29.4.tar.gz", hash = "sha256:bbbf02701d2bf4ee5a88c5c9be575bff9d7f43bc59d840c4aa493a106132ee22", size = 421264, upload-time = "2026-05-07T19:47:37.766Z" }
@@ -854,6 +886,18 @@ wheels = [
 ]
 
 [[package]]
+name = "decopatch"
+version = "1.4.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "makefun" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/4c/8ca1f193428cbc4d63d0f07db9b8bd96be2db8ee5deefa93e7e8a28f2812/decopatch-1.4.10.tar.gz", hash = "sha256:957f49c93f4150182c23f8fb51d13bb3213e0f17a79e09c8cca7057598b55720", size = 69538, upload-time = "2022-03-01T08:57:21.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/fa/8e4a51e1afda8d4bd73d784bfe4a60cfdeeced9bea419eff5c271180377e/decopatch-1.4.10-py2.py3-none-any.whl", hash = "sha256:e151f7f93de2b1b3fd3f3272dcc7cefd1a69f68ec1c2d8e288ecd9deb36dc5f7", size = 18015, upload-time = "2022-03-01T08:57:20.676Z" },
+]
+
+[[package]]
 name = "deepdiff"
 version = "8.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -931,6 +975,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -1533,6 +1586,35 @@ wheels = [
 ]
 
 [[package]]
+name = "ibis-framework"
+version = "12.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "atpublic" },
+    { name = "parsy" },
+    { name = "python-dateutil" },
+    { name = "sqlglot" },
+    { name = "toolz" },
+    { name = "typing-extensions" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8e/2e7ad9bdeaf45350da7beeb67a0d4317d400dac882825eb7c3bd4d3c6ae1/ibis_framework-12.0.0.tar.gz", hash = "sha256:238624f2c14fdab8382ca2f4f667c3cdb81e29844cd5f8db8a325d0743767c61", size = 1351369, upload-time = "2026-02-07T14:31:13.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/b3/11d406849715b47c9d69bb22f50874f80caee96bd1cbe7b61abbebbf5a05/ibis_framework-12.0.0-py3-none-any.whl", hash = "sha256:0bbd790f268da9cb87926d5eaad2b827a573927113c4ed3be5095efa89b9e512", size = 2079219, upload-time = "2026-02-07T14:31:10.646Z" },
+]
+
+[package.optional-dependencies]
+duckdb = [
+    { name = "duckdb" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyarrow-hotfix" },
+    { name = "rich" },
+]
+
+[[package]]
 name = "idna"
 version = "3.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1784,6 +1866,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "gspread" },
     { name = "lxml" },
+    { name = "metaxy", extra = ["dagster", "duckdb"] },
     { name = "networkx" },
     { name = "openai" },
     { name = "pdfplumber" },
@@ -1822,14 +1905,14 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.0,<5.0.0" },
     { name = "dagster", specifier = ">=1.12.18,<2.0.0" },
     { name = "dagster-cloud" },
-    { name = "dagster-dbt" },
+    { name = "dagster-dbt", specifier = ">=0.28.18,<1.0.0" },
     { name = "dagster-dg-cli", specifier = ">=1.12.18,<2.0.0" },
     { name = "dagster-docker", specifier = ">=0.28.18,<1.0.0" },
     { name = "dagster-duckdb" },
     { name = "dagster-pipes", specifier = ">=1.12.18,<2.0.0" },
     { name = "dagster-postgres", specifier = ">=0.28.18,<1.0.0" },
     { name = "dagster-shared", specifier = ">=1.12.18,<2.0.0" },
-    { name = "dagster-sling" },
+    { name = "dagster-sling", specifier = ">=0.28.18,<1.0.0" },
     { name = "dagster-webserver", specifier = ">=1.12.18,<2.0.0" },
     { name = "dagster-webserver", marker = "extra == 'dev'" },
     { name = "dbt-core", specifier = ">=1.11.10,<2.0.0" },
@@ -1845,6 +1928,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.0.0,<2.0.0" },
     { name = "gspread", specifier = ">=6.0.0,<7.0.0" },
     { name = "lxml", specifier = ">=5.0.0,<7.0.0" },
+    { name = "metaxy", extras = ["duckdb", "dagster"], specifier = ">=0.1.10,<0.2.0" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "networkx", specifier = ">=3.2.0,<4.0.0" },
     { name = "openai", specifier = ">=1.0.0,<3.0.0" },
@@ -1864,13 +1948,22 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.12.0,<2.0.0" },
     { name = "sqlfluff", marker = "extra == 'dev'", specifier = ">=3.4.2,<4.0.0" },
     { name = "sqlfluff-templater-dbt", marker = "extra == 'dev'", specifier = ">=3.4.2,<4.0.0" },
-    { name = "sqlglot", specifier = ">=25.0.0,<27.0.0" },
+    { name = "sqlglot", specifier = ">=28.1.0,<29.0.0" },
     { name = "tenacity", specifier = ">=9.1.2,<10.0.0" },
     { name = "ty", marker = "extra == 'dev'" },
     { name = "vadersentiment", specifier = ">=3.3.2" },
     { name = "vl-convert-python", specifier = ">=1.6.0,<2.0.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "makefun"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/cf/6780ab8bc3b84a1cce3e4400aed3d64b6db7d5e227a2f75b6ded5674701a/makefun-1.16.0.tar.gz", hash = "sha256:e14601831570bff1f6d7e68828bcd30d2f5856f24bad5de0ccb22921ceebc947", size = 73565, upload-time = "2025-05-09T15:00:42.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/c0/4bc973defd1270b89ccaae04cef0d5fa3ea85b59b108ad2c08aeea9afb76/makefun-1.16.0-py2.py3-none-any.whl", hash = "sha256:43baa4c3e7ae2b17de9ceac20b669e9a67ceeadff31581007cca20a07bbe42c4", size = 22923, upload-time = "2025-05-09T15:00:41.042Z" },
+]
 
 [[package]]
 name = "mako"
@@ -1948,6 +2041,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "metaxy"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cyclopts" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "polars" },
+    { name = "polars-hash" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "pydantic-settings" },
+    { name = "pytest-cases" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "sqlglot" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+    { name = "tomlkit" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/4b/0d2a386ed7684cd28ecc895a855680f98e3cebad812b83fd2a4ef0e3dbaf/metaxy-0.1.10.tar.gz", hash = "sha256:62b4970cdc196ee1f31a3cc972002a521fbea1dc1280db66fd540fec1456030e", size = 254981, upload-time = "2026-04-10T09:55:39.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/b0/743f0ea70d79c251c1ef25837754c9831f57f582b5f5e61eb35edac5a64a/metaxy-0.1.10-py3-none-any.whl", hash = "sha256:480ef9d357fcb1e282f0ecb703a57632d43b809b6819f6d00976fe284b15e855", size = 326521, upload-time = "2026-04-10T09:55:40.142Z" },
+]
+
+[package.optional-dependencies]
+dagster = [
+    { name = "dagster" },
+    { name = "dagster-shared" },
+]
+duckdb = [
+    { name = "duckdb" },
+    { name = "ibis-framework", extra = ["duckdb"] },
 ]
 
 [[package]]
@@ -2147,12 +2278,42 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/16/b5c76b838fd9bf6ce84d3a53346b8874ec05c5f0040d75ef2c320100cd2a/pandas-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:455f6f8139d4282188f526868dbc3c828470e88a3d9d59a891bd46a455f21b98", size = 10338495, upload-time = "2026-05-11T18:52:11.558Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b0/a4ffc4ae74d2d822200dcc46898987d8eb6032d1e2b219cae39da6f5cbcc/pandas-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4e15135e2ee5df1063313e2425ceef8ac0f4ae775893815b0923651b806a5639", size = 9938250, upload-time = "2026-05-11T18:52:17.005Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b2/3323601a52caee42c019e370090ca4544b241437240ca04f786cce82b0cf/pandas-3.0.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:05f1f1752b8533ea03f7f39a9c15b1a058d067bb48f4748948e7a8691e0510f2", size = 10770558, upload-time = "2026-05-11T18:52:19.865Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/bbecd2f867b97abebe0f9b53d750f862251b40337e061b36676ded3d920f/pandas-3.0.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a1e45c80cceb3b4a21bc5939d52e8cbd8d9b7305309219d59e9754d9ce09e27", size = 11274611, upload-time = "2026-05-11T18:52:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/4f/eafabf2d5fae5adf143b4d18d3706c5efdc368a7c4eb1ee8a3eddabbd0f6/pandas-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:14da8316da4d0c5a77618425996bfb1248ca87fc2c1486e6fde4652bd18b5824", size = 11784670, upload-time = "2026-05-11T18:52:25.4Z" },
+    { url = "https://files.pythonhosted.org/packages/49/44/1eb20389301b57b19cc099a1c2f662501f72f08a65f912d05822613c1532/pandas-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a55066a0505dae0ba2b50a46637db34b46f9094c65c5d4800794ef6335010938", size = 12353708, upload-time = "2026-05-11T18:52:28.139Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/c321f13b5ba1819fc8dca456c7fce578da2dcfecff1abbf0eaddf8406c0f/pandas-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6674ab18ad8c57802867264b00e15e7bb904700cdd9046e3b2fa1fce237439ea", size = 9907609, upload-time = "2026-05-11T18:52:30.982Z" },
+    { url = "https://files.pythonhosted.org/packages/53/85/1b7f563ebc6357c27233a02a96b589bcce1fa9c6eb89fb4f0e56421d277e/pandas-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:5cc09a68b3120e0f54870dede8287a7bb1fa463907e4fcec1ea77cab6179bf7a", size = 9165596, upload-time = "2026-05-11T18:52:33.334Z" },
+]
+
+[[package]]
 name = "parsedatetime"
 version = "2.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a8/20/cb587f6672dbe585d101f590c3871d16e7aec5a576a1694997a3777312ac/parsedatetime-2.6.tar.gz", hash = "sha256:4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455", size = 60114, upload-time = "2020-05-31T23:50:57.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/a4/3dd804926a42537bf69fb3ebb9fd72a50ba84f807d95df5ae016606c976c/parsedatetime-2.6-py3-none-any.whl", hash = "sha256:cb96edd7016872f58479e35879294258c71437195760746faffedb692aef000b", size = 42548, upload-time = "2020-05-31T23:50:56.315Z" },
+]
+
+[[package]]
+name = "parsy"
+version = "2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/58/1e3f382eef9e50a2a115486b0c178d22bb97d2fbb85421ccbe5d3a783530/parsy-2.2.tar.gz", hash = "sha256:e943147644a8cf0d82d1bcb5c5867dd517495254cea3e3eb058b1e421cb7561f", size = 47296, upload-time = "2025-09-12T11:39:26.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/fc/8cb9073bb1bee54eb49a1ae501a36402d01763812962ac811cdc1c81a9d7/parsy-2.2-py3-none-any.whl", hash = "sha256:5e981613d9d2d8b68012d1dd0afe928967bea2e4eefdb76c2f545af0dd02a9e7", size = 9538, upload-time = "2025-09-12T11:39:25.749Z" },
 ]
 
 [[package]]
@@ -2263,6 +2424,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
+]
+
+[[package]]
+name = "polars-hash"
+version = "0.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/65/1363800e877a6839398628879fcaef8623fab8abedd0e2e2eb4657282550/polars_hash-0.5.6.tar.gz", hash = "sha256:c0e5c02e839dac8d4c514fb3a053f2dc33749bd5ed1cb5387c1ef34972492e38", size = 28154, upload-time = "2026-01-09T10:47:25.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/96/7aad5784ea758dfcac1e89aeb87a9ebc81ee939a8a79f59b8d41f392ff1a/polars_hash-0.5.6-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:92d5d7192e1b877287efd73abdf6df080f562fa3b758fae49f0cd1bcaee8817f", size = 4230486, upload-time = "2026-01-09T10:47:08.362Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/0c/bf1db13c707956be8acdcc56ca7440d8f0706d80f9a2a56fbedf598dc3d9/polars_hash-0.5.6-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:2c70d9f1ffdabd610aeafad965fbf753fc526c84a0153e00987ee872a4d10c30", size = 4011494, upload-time = "2026-01-09T10:47:10.448Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d1/ab5e0242ec78965f9c767c6b453d2972c799125fb5aba0714cf90a58c077/polars_hash-0.5.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c772db0140f34ca068b01116d430caf994ef23917c31b44db68c511f208a72a7", size = 4845209, upload-time = "2026-01-09T10:47:12.133Z" },
+    { url = "https://files.pythonhosted.org/packages/19/3b/65d234b23251fcce5bb8e3c48764fbb017d5627b20dce401e8b20009b9a6/polars_hash-0.5.6-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aef82274bfd05b4dbca740a2a7db13d5ce9aeb678c3ffd593d61a8a3f8a2cdf8", size = 4973914, upload-time = "2026-01-09T10:47:13.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/ceca8f33fd8b4da203ad989c1d8dff36459a0c6c50c0cdee335a19380a74/polars_hash-0.5.6-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a63fbfe49f14a8fb966db00162eab7067e270d9fbc8261c4e4109c752aea9f8a", size = 5519486, upload-time = "2026-01-09T10:47:15.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/75/537a7cf9bf067db271c89c5033d63445aa3a99d885ee801f77c28f2e87d2/polars_hash-0.5.6-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d612bb3f7c18bbb525d489c21fe803e89253c41fe7a8a5c08231e81ecff771f5", size = 5631602, upload-time = "2026-01-09T10:47:18.115Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0c/ceee8533b4e8b1df61a65453d0454be99954262e8678a6a726d1860f61c4/polars_hash-0.5.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c7980c07510e39414b6a54de5241cca18a919c0d23fee24de76b044ef17af1a", size = 4897827, upload-time = "2026-01-09T10:47:20.336Z" },
+    { url = "https://files.pythonhosted.org/packages/94/74/3b49440046260b34f1d91e779bf64aefe673401e30b7ec648f94eb90c82b/polars_hash-0.5.6-cp38-abi3-win32.whl", hash = "sha256:004db887b202f2e9e0bc22d3b5bf0b8d3a6cc5caaa38858c564d95dc9e9ff985", size = 3653821, upload-time = "2026-01-09T10:47:22.066Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/58/94016e8e61f210175146e25e40a6ea8a498e94eeaa4214e5f4cb1d8458fa/polars_hash-0.5.6-cp38-abi3-win_amd64.whl", hash = "sha256:5f745a52054779cc1c03950a905dc7fc971698b6111e3e83e24d4edf502d9e6c", size = 4187808, upload-time = "2026-01-09T10:47:24.176Z" },
 ]
 
 [[package]]
@@ -2391,6 +2572,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow-hotfix"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/ed/c3e8677f7abf3981838c2af7b5ac03e3589b3ef94fcb31d575426abae904/pyarrow_hotfix-0.7.tar.gz", hash = "sha256:59399cd58bdd978b2e42816a4183a55c6472d4e33d183351b6069f11ed42661d", size = 9910, upload-time = "2025-04-25T10:17:06.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/c3/94ade4906a2f88bc935772f59c934013b4205e773bcb4239db114a6da136/pyarrow_hotfix-0.7-py3-none-any.whl", hash = "sha256:3236f3b5f1260f0e2ac070a55c1a7b339c4bb7267839bd2015e283234e758100", size = 7923, upload-time = "2025-04-25T10:17:05.224Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2471,6 +2661,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
 ]
 
 [[package]]
@@ -2596,6 +2800,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cases"
+version = "3.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decopatch" },
+    { name = "makefun" },
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/a2/c7abc3b606125cf3732e8e613092b0e2549365e824b5f37972125c22806b/pytest_cases-3.10.1.tar.gz", hash = "sha256:451f9e3ecd5d2d81a4362c10c441126f5b3d1ae3a7efaf59f60b1fb930df2d69", size = 1095867, upload-time = "2026-03-02T23:05:33.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/f2/7a29fb0571562034b05c38dceabba48dcc622be5d6c5448db80779e55de7/pytest_cases-3.10.1-py2.py3-none-any.whl", hash = "sha256:0deb8a85b6132e44adbc1cfc57897c6a624ec23f48ab445a43c7d56a6b9315a4", size = 108870, upload-time = "2026-03-02T23:05:32.663Z" },
 ]
 
 [[package]]
@@ -2804,6 +3023,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
 ]
 
 [[package]]
@@ -3051,34 +3283,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "26.33.0"
+version = "28.10.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/9d/fcd59b4612d5ad1e2257c67c478107f073b19e1097d3bfde2fb517884416/sqlglot-26.33.0.tar.gz", hash = "sha256:2817278779fa51d6def43aa0d70690b93a25c83eb18ec97130fdaf707abc0d73", size = 5353340, upload-time = "2025-07-01T13:09:06.311Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/66/b2b300f325227044aa6f511ea7c9f3109a1dc74b13a0897931c1754b504e/sqlglot-28.10.1.tar.gz", hash = "sha256:66e0dae43b4bce23314b80e9aef41b8c88fea0e17ada62de095b45262084a8c5", size = 5739510, upload-time = "2026-02-09T23:36:23.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/8d/f1d9cb5b18e06aa45689fbeaaea6ebab66d5f01d1e65029a8f7657c06be5/sqlglot-26.33.0-py3-none-any.whl", hash = "sha256:031cee20c0c796a83d26d079a47fdce667604df430598c7eabfa4e4dfd147033", size = 477610, upload-time = "2025-07-01T13:09:03.926Z" },
-]
-
-[package.optional-dependencies]
-rs = [
-    { name = "sqlglotrs" },
-]
-
-[[package]]
-name = "sqlglotrs"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/59/13/e77dcfd72b849a113bea7ccee79329f77751704e66560410176b1f4657f9/sqlglotrs-0.6.1.tar.gz", hash = "sha256:f638a7a544698ade8b0c992c8c67feae17bd5c2c760114ab164bd0b7dc8911e1", size = 15420, upload-time = "2025-06-04T11:35:28.831Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/af/121c2e4190356d0296378677a71d72c406647c5e153bc883a801cca70a01/sqlglotrs-0.6.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c99b00ab3c88521c4f6431b1bd18bad336b45ec95c2c188da4a59984fdaedffe", size = 316735, upload-time = "2025-06-04T11:35:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ab/cf64e66de68e7208ebef7bbed1441b2b49ed41f654aad1e3b0f688ec795f/sqlglotrs-0.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5c8edf24124f94460f41b68044958cfc0a13ad20f6a148e10e840ebb10fbf2f", size = 304504, upload-time = "2025-06-04T11:35:16.807Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/fd/70dcfd20b8ce839180c9be17a06bd46948281f185501bb7f1539f9361412/sqlglotrs-0.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b99c1233eae4c11098fa59009932f2c5e14c06fdc4745bc4004fcf21e0c61eb7", size = 336017, upload-time = "2025-06-04T11:34:29.344Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/6e/6ae6a5c6ac3e2b7c5d24a8fda6171bc60c7d1010e95fac5feed1bf9c6c91/sqlglotrs-0.6.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:79233885ecb12a6c16be87c346954cadd0806e607cd62808d981dc3b029b88b0", size = 345714, upload-time = "2025-06-04T11:34:37.754Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/dd/31e654d760e0b10ed1d15157690131e983b0edf607b6d318006170f251a1/sqlglotrs-0.6.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c340fd06d92f1dd1c6d6ea3926b7c6865af7d018a944622f5715c0622533fc5b", size = 486116, upload-time = "2025-06-04T11:34:54.908Z" },
-    { url = "https://files.pythonhosted.org/packages/48/01/6f4da6389f86a26c715c4e8937e2e6e499394d33db42f87ebf0d87ad18b7/sqlglotrs-0.6.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3898f1b07c9f17a1e3f095a1b6dd008447899a2d636ed4c74a953df45ad6cdca", size = 373777, upload-time = "2025-06-04T11:35:01.95Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/26/a4cad155f33aa96e81b62d02c119ec165d0689fe485cd0d19867d62054a9/sqlglotrs-0.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d1ac532bd4f9c76e658542441b0e6ada931856b69d9dbfc076947c6498606dc", size = 340494, upload-time = "2025-06-04T11:35:09.698Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ac/d199a64c155f71fc9db6c400388fb5272479988fcc1b52b292bce3826017/sqlglotrs-0.6.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6fb1a250d1e8066b34d8f900762534d81f1ccc0d41aa157ed6b26e5712834c5d", size = 365531, upload-time = "2025-06-04T11:34:47.022Z" },
-    { url = "https://files.pythonhosted.org/packages/79/71/b16ba44b41c4b9981c177eee39c0092900721465d3439b8cab15ab5b23ac/sqlglotrs-0.6.1-cp311-cp311-win32.whl", hash = "sha256:32617a5ed23703d55c5cc92b02b56269fb8838f6ed5b45d7a4aaba27a4c5a4c8", size = 186529, upload-time = "2025-06-04T11:35:30.625Z" },
-    { url = "https://files.pythonhosted.org/packages/40/63/d6f86a732632dd5773b1b7afbc8be53ba1d96858dd75050c2c59317ee4ed/sqlglotrs-0.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:1fc86e8c9a6d097eedc7d3c7218ea0376793a03a8abedd4dce22001fc314edd1", size = 199329, upload-time = "2025-06-04T11:35:37.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ff/5a768b34202e1ee485737bfa167bd84592585aa40383f883a8e346d767cc/sqlglot-28.10.1-py3-none-any.whl", hash = "sha256:214aef51fd4ce16407022f81cfc80c173409dab6d0f6ae18c52b43f43b31d4dd", size = 597053, upload-time = "2026-02-09T23:36:21.385Z" },
 ]
 
 [[package]]
@@ -3231,12 +3440,30 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b1/09/a439bec5888f00a54b8b9f05fa94d7f901d6735ef4e55dcec9bc37b5d8fa/tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79", size = 192885, upload-time = "2024-08-14T08:19:41.488Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde", size = 37955, upload-time = "2024-08-14T08:19:40.05Z" },
+]
+
+[[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
 ]
 
 [[package]]

--- a/macro_agents/uv.lock
+++ b/macro_agents/uv.lock
@@ -8,7 +8,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "sqlglot", specifier = ">=28.1.0,<29.0.0" }]
+overrides = [
+    { name = "sqlglot", specifier = ">=28.1.0,<29.0.0" },
+    { name = "sqlglotrs", specifier = ">=0.12.0,<0.13.0" },
+]
 
 [[package]]
 name = "agate"


### PR DESCRIPTION
Closes #46.

Integrate **Metaxy 0.1.10** into the SEC filing pipeline as a sample-level metadata layer, exercising every lineage type Metaxy supports.

## Coverage

| Feature | Lineage | Asset | id_columns |
|---|---|---|---|
| \`sec/raw_html\` | source | (graph-only) | filing_id |
| \`sec/extracted_text\` | identity ← raw_html | \`sec_filing_text_extracted\` | filing_id |
| \`sec/bi_signals\` | expansion ← extracted_text | \`sec_filing_business_intelligence\` | term_id |
| \`sec/embeddings\` | expansion ← extracted_text | \`sec_filing_search_index\` | chunk_id |
| \`sec/fts_index\` | expansion ← extracted_text | \`sec_filing_fts_index\` | content_id |
| \`sec/search_index\` | **aggregation ← embeddings + fts_index** (multi-parent) | \`sec_filing_hybrid_search_ready\` | filing_id |

## What's in the PR

- \`macro_agents/metaxy.toml\` — store name \`prod\`, DuckDB backend (MotherDuck) configured via env var
- \`defs/domains/sec/lineage.py\` — six \`BaseFeature\` subclasses covering the SEC graph
- Every SEC asset wrapped with \`@metaxify(key=...)\` (key pinned so downstream \`deps=[...]\` references continue to resolve)
- Shadow-mode block in each asset: computes Metaxy's stale-id set and compares to the asset's existing boolean query. Differences surfaced as \`metaxy_stale_count\` / \`metaxy_divergence_count\` asset metadata. Wrapped in try/except — a store outage cannot fail the asset
- \`MetaxyStoreFromConfigResource(name="prod")\` registered as resource \`metaxy_store\`
- \`MetaxyConfig.set(MetaxyConfig.load())\` invoked on lineage import so toml + env are merged before the first feature class is evaluated
- Dep extras: \`metaxy[duckdb,dagster]\` (pulls \`ibis\`), plus uv override-dependencies for \`sqlglot>=28.1\` and \`sqlglotrs>=0.12\` to bridge metaxy's pin against dagster-dbt's
- Tests for all six FeatureSpecs (including the multi-parent aggregation shape)

## Verification

End-to-end materialization of \`sec_filing_text_extracted\` against MotherDuck:
- Metaxy config loaded ✓
- Feature graph populated at import ✓
- \`@metaxify\` wraps asset, asset key preserved ✓
- \`MetaxyStoreFromConfigResource\` opens DuckDB→MotherDuck connection ✓
- Asset ran through extraction (10-K with 20 sections + 10-Q with 8 sections, 254 sections to GCS) ✓
- Reached final upsert (failed on pre-existing schema drift fixed in #70/#71, since merged)

## Operator setup

1. \`CREATE DATABASE econ_data_metaxy\` on MotherDuck (one-time; already done for prod)
2. Set \`METAXY_STORES__PROD__CONFIG__DATABASE=md:econ_data_metaxy?motherduck_token=$MOTHERDUCK_TOKEN\` in the env

## CI gates

- [x] \`ruff check\` + \`ruff format --check\`
- [x] \`ty check\` (caught two real API mistakes during the build — see commit \`eeefb9c\`)
- [x] \`dg check defs\`
- [x] \`pytest tests/ -m "not skip_ci"\` — 442 passed

## Phase exit criteria (for follow-up monitoring after merge)

- 3 consecutive prod runs of \`sec_filing_text_extracted\` with \`metaxy_divergence_count == 0\`
- One deliberate code-version bump (extractor signature change) confirms Metaxy flags only the affected filings as stale
- Once stable across all six features for a week, drop \`sec_filings.processed\` as the truth column

🤖 Generated with [Claude Code](https://claude.com/claude-code)