### PR TITLE
fix(sec): drop legacy content_text/created_at on sec_filing_content (#70)

### DIFF
--- a/macro_agents/src/macro_agents/defs/domains/sec/tables.py
+++ b/macro_agents/src/macro_agents/defs/domains/sec/tables.py
@@ -111,19 +111,48 @@ def ensure_sec_filing_documents_table(conn: duckdb.DuckDBPyConnection) -> None:
 
 
 def ensure_sec_filing_content_table(conn: duckdb.DuckDBPyConnection) -> None:
-    """Create sec_filing_content table if it doesn't exist."""
+    """Create sec_filing_content table if it doesn't exist.
+
+    Issue #70: this table used to have `content_text TEXT` and
+    `created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP`. Section text moved to
+    GCS (single source of truth), and `created_at` was never read. The
+    asset writes a 6-column DataFrame; `upsert_data` does strict schema
+    equality, so the legacy columns broke the bulk upsert.
+
+    DuckDB blocks ALTER TABLE on indexed tables, so the migration drops
+    indexes first, then columns, then recreates indexes. The whole dance
+    is gated on the presence of the legacy columns so it only fires once.
+    """
     conn.execute("""
         CREATE TABLE IF NOT EXISTS sec_filing_content (
             content_id VARCHAR PRIMARY KEY,
             filing_id VARCHAR NOT NULL,
             section_name VARCHAR,
             section_order INTEGER,
-            content_text TEXT,
             word_count INTEGER,
-            gcs_path VARCHAR,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            gcs_path VARCHAR
         )
     """)
+
+    legacy_columns_row = conn.execute(
+        "SELECT COUNT(*) FROM duckdb_columns() "
+        "WHERE table_name = 'sec_filing_content' "
+        "AND database_name = current_database() "
+        "AND schema_name = current_schema() "
+        "AND column_name IN ('content_text', 'created_at')"
+    ).fetchone()
+    legacy_columns_present = (
+        (legacy_columns_row[0] or 0) > 0 if legacy_columns_row else False
+    )
+
+    if legacy_columns_present:
+        conn.execute("DROP INDEX IF EXISTS idx_sec_filing_content_filing_id")
+        conn.execute("DROP INDEX IF EXISTS idx_sec_filing_content_filing_section")
+        conn.execute(
+            "ALTER TABLE sec_filing_content DROP COLUMN IF EXISTS content_text"
+        )
+        conn.execute("ALTER TABLE sec_filing_content DROP COLUMN IF EXISTS created_at")
+
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_sec_filing_content_filing_id
         ON sec_filing_content(filing_id)

--- a/macro_agents/tests/test_sec_filing_content_schema.py
+++ b/macro_agents/tests/test_sec_filing_content_schema.py
@@ -1,0 +1,106 @@
+"""Schema migration tests for sec_filing_content (issue #70).
+
+The asset writes 6 columns (content_id, filing_id, section_name,
+section_order, word_count, gcs_path). The legacy schema also had
+content_text TEXT and created_at TIMESTAMP, which made md.upsert_data
+fail its strict schema-equality check. These tests verify that
+ensure_sec_filing_content_table converges any legacy schema to the new
+shape without losing the indexes.
+"""
+
+import duckdb
+
+from macro_agents.defs.domains.sec.tables import ensure_sec_filing_content_table
+
+
+EXPECTED_COLUMNS = {
+    "content_id",
+    "filing_id",
+    "section_name",
+    "section_order",
+    "word_count",
+    "gcs_path",
+}
+EXPECTED_INDEXES = {
+    "idx_sec_filing_content_filing_id",
+    "idx_sec_filing_content_filing_section",
+}
+
+
+def _columns(conn: duckdb.DuckDBPyConnection) -> set[str]:
+    rows = conn.execute(
+        "SELECT column_name FROM duckdb_columns() "
+        "WHERE table_name = 'sec_filing_content'"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _indexes(conn: duckdb.DuckDBPyConnection) -> set[str]:
+    rows = conn.execute(
+        "SELECT index_name FROM duckdb_indexes() "
+        "WHERE table_name = 'sec_filing_content'"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def test_creates_fresh_table_with_expected_shape():
+    conn = duckdb.connect(":memory:")
+    ensure_sec_filing_content_table(conn)
+    assert _columns(conn) == EXPECTED_COLUMNS
+    assert _indexes(conn) == EXPECTED_INDEXES
+
+
+def test_idempotent_on_already_migrated_table():
+    conn = duckdb.connect(":memory:")
+    ensure_sec_filing_content_table(conn)
+    ensure_sec_filing_content_table(conn)
+    assert _columns(conn) == EXPECTED_COLUMNS
+    assert _indexes(conn) == EXPECTED_INDEXES
+
+
+def test_migrates_legacy_schema_with_content_text_and_created_at():
+    conn = duckdb.connect(":memory:")
+    # Recreate the pre-#70 schema exactly.
+    conn.execute("""
+        CREATE TABLE sec_filing_content (
+            content_id VARCHAR PRIMARY KEY,
+            filing_id VARCHAR NOT NULL,
+            section_name VARCHAR,
+            section_order INTEGER,
+            content_text TEXT,
+            word_count INTEGER,
+            gcs_path VARCHAR,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX idx_sec_filing_content_filing_id ON sec_filing_content(filing_id)"
+    )
+    conn.execute(
+        "CREATE INDEX idx_sec_filing_content_filing_section "
+        "ON sec_filing_content(filing_id, section_name)"
+    )
+
+    ensure_sec_filing_content_table(conn)
+
+    assert _columns(conn) == EXPECTED_COLUMNS
+    assert _indexes(conn) == EXPECTED_INDEXES
+
+
+def test_migrates_partial_legacy_schema_with_only_content_text():
+    """Only `content_text` present (no `created_at`). Migration should
+    still drop it and converge."""
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE sec_filing_content (
+            content_id VARCHAR PRIMARY KEY,
+            filing_id VARCHAR NOT NULL,
+            section_name VARCHAR,
+            section_order INTEGER,
+            content_text TEXT,
+            word_count INTEGER,
+            gcs_path VARCHAR
+        )
+    """)
+    ensure_sec_filing_content_table(conn)
+    assert _columns(conn) == EXPECTED_COLUMNS


### PR DESCRIPTION
Closes #70.

## Summary
- Drops two legacy columns (\`content_text\`, \`created_at\`) from \`sec_filing_content\` so the table matches what the asset actually writes
- \`md.upsert_data\` does strict schema-equality, so the drift broke the bulk upsert at the end of \`sec_filing_text_extracted\`
- Audit before the change: table was empty (0 rows on prod), so no data loss

## What changed
- \`ensure_sec_filing_content_table\` declares the new 6-column shape and contains an idempotent migration block: drop dependent indexes → drop legacy columns if present → recreate indexes. Gated on a metadata lookup so it only fires once
- New tests cover: fresh table creation, idempotency on already-migrated tables, full legacy schema migration, and partial legacy (only \`content_text\`)

## Prod migration
Already executed against MotherDuck \`prod_econ\` while preparing this PR. The auto-migration in \`ensure_sec_filing_content_table\` covers any other env (dev, CI, future installs).

## Test plan
- [x] \`pytest tests/test_sec_filing_content_schema.py -v\` — 4 passed
- [x] Full \`pytest tests/ -m \"not skip_ci\"\` — 436 passed
- [x] \`ruff check\` + \`ruff format --check\`
- [x] \`ty check\`
- [x] \`dg check defs\`
- [ ] After merge, materialize \`sec_filing_text_extracted\` end-to-end and confirm bulk upsert succeeds (unblocks #46 Phase 2 exit criteria)

🤖 Generated with [Claude Code](https://claude.com/claude-code)