### PR TITLE
fix: update migration scripts to use econ_agent as source database

### DIFF
--- a/scripts/migrate_motherduck_to_bq.py
+++ b/scripts/migrate_motherduck_to_bq.py
@@ -1,41 +1,37 @@
-"""Migrate raw data tables from MotherDuck to BigQuery.
-
-Phase 4 of the BigQuery migration (issue #79).
+"""Migrate data tables from MotherDuck to BigQuery.
 
 Usage:
     # Dry run — print what would be migrated without doing anything
     uv run python scripts/migrate_motherduck_to_bq.py --dry-run
 
-    # Migrate all raw tables
+    # Migrate all non-empty tables from econ_agent
     uv run python scripts/migrate_motherduck_to_bq.py
 
-    # Migrate specific tables only
-    uv run python scripts/migrate_motherduck_to_bq.py --tables sp500_companies_raw fred_series_raw
+    # Migrate a specific database
+    uv run python scripts/migrate_motherduck_to_bq.py --database prod_econ
 
-    # Skip the GCS intermediate step and load directly (requires enough local memory)
-    uv run python scripts/migrate_motherduck_to_bq.py --direct
+    # Migrate specific tables only
+    uv run python scripts/migrate_motherduck_to_bq.py --tables sp500_companies_prices_raw fred_raw
+
+    # Include empty tables (skipped by default)
+    uv run python scripts/migrate_motherduck_to_bq.py --include-empty
 
 Prerequisites:
-    - MOTHERDUCK_TOKEN set in environment (for duckdb motherduck connection)
-    - BIGQUERY_PROJECT, BIGQUERY_DATASET set (or defaults used)
-    - GCS_BUCKET_NAME set (used as staging area for large tables)
-    - GOOGLE_APPLICATION_CREDENTIALS pointing to service account JSON
-    - uv environment with both duckdb and google-cloud-bigquery installed
+    - MOTHERDUCK_TOKEN set in environment
+    - MOTHERDUCK_DATABASE set (default: econ_agent)
+    - BIGQUERY_PROJECT set
+    - GOOGLE_APPLICATION_CREDENTIALS pointing to service account JSON, or gcloud ADC active
+    - uv environment with duckdb and google-cloud-bigquery installed
 
 Strategy:
-    1. Connect to MotherDuck
-    2. For each raw table: export to GCS as Parquet via DuckDB httpfs
-    3. Load each GCS Parquet into BigQuery via load job
-    4. Print row count reconciliation
-
-For tables too large to fit in memory, use GCS as an intermediate staging area.
+    Reads each table from MotherDuck into memory via Arrow and loads directly into
+    BigQuery. At ~11 MB total this is faster and cheaper than routing through GCS.
 """
 
 import argparse
 import logging
 import os
 import sys
-from datetime import datetime
 
 logging.basicConfig(
     level=logging.INFO,
@@ -43,39 +39,8 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-# Raw tables written by Dagster assets (in economics_raw dataset)
-RAW_TABLES = [
-    "sp500_companies_raw",
-    "nasdaq_companies_raw",
-    "stock_prices_raw",
-    "stock_splits_raw",
-    "stock_dividends_raw",
-    "commodity_prices_raw",
-    "fred_series_raw",
-    "fred_observations_raw",
-    "housing_zillow_raw",
-    "housing_realtor_raw",
-    "fomc_transcripts_raw",
-    "fomc_meeting_dates_raw",
-    "reddit_posts_raw",
-    "reddit_comments_raw",
-    "sec_company_cik",
-    "sec_company_cik_history",
-    "sec_filings",
-    "sec_filing_documents",
-    "sec_filing_content",
-    "sec_filing_markdown",
-    "sec_filing_llm_metadata",
-    "sec_filing_search_terms",
-    "sec_filing_chunks",
-    "telemetry_events_raw",
-    "economic_calendar_raw",
-    "ai_model_benchmarks_raw",
-]
 
-
-def get_motherduck_connection():
-    """Connect to MotherDuck using MOTHERDUCK_TOKEN env var."""
+def get_motherduck_connection(database: str):
     try:
         import duckdb
     except ImportError:
@@ -83,7 +48,6 @@ def get_motherduck_connection():
         sys.exit(1)
 
     token = os.environ.get("MOTHERDUCK_TOKEN")
-    database = os.environ.get("MOTHERDUCK_DATABASE", "my_db")
     if not token:
         log.error("MOTHERDUCK_TOKEN environment variable not set")
         sys.exit(1)
@@ -94,95 +58,37 @@ def get_motherduck_connection():
 
 
 def get_bq_client():
-    """Get a BigQuery client using ADC or service account credentials."""
     from google.cloud import bigquery
-
     project = os.environ.get("BIGQUERY_PROJECT")
     return bigquery.Client(project=project)
 
 
-def list_existing_tables(md_conn, schema: str = "main") -> list[str]:
-    """List all tables in the given MotherDuck schema."""
+def list_tables(md_conn, database: str, schema: str = "main", include_empty: bool = False) -> list[str]:
+    """List tables in the given database/schema, optionally filtering out empty ones."""
     rows = md_conn.execute(
-        f"SELECT table_name FROM information_schema.tables "
-        f"WHERE table_schema = '{schema}' AND table_type = 'BASE TABLE'"
+        f"""
+        SELECT t.table_name
+        FROM information_schema.tables t
+        JOIN duckdb_tables() d
+          ON d.table_name = t.table_name
+          AND d.schema_name = t.table_schema
+          AND d.database_name = t.table_catalog
+        WHERE t.table_catalog = '{database}'
+          AND t.table_schema = '{schema}'
+          AND t.table_type = 'BASE TABLE'
+          {'AND d.estimated_size > 0' if not include_empty else ''}
+        ORDER BY d.estimated_size DESC
+        """
     ).fetchall()
     return [r[0] for r in rows]
 
 
 def get_row_count(md_conn, table: str) -> int:
-    """Get approximate row count from MotherDuck."""
     row = md_conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
     return row[0] if row else 0
 
 
-def migrate_table_via_gcs(
-    md_conn,
-    bq_client,
-    table: str,
-    project: str,
-    dataset: str,
-    gcs_bucket: str,
-    dry_run: bool = False,
-) -> dict:
-    """Export table to GCS Parquet then load into BigQuery."""
-    from google.cloud import bigquery, storage
-
-    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-    gcs_path = f"gs://{gcs_bucket}/migration/{timestamp}/{table}/*.parquet"
-    bq_table_ref = f"{project}.{dataset}.{table}"
-
-    md_count = get_row_count(md_conn, table)
-    log.info(f"  MotherDuck rows: {md_count:,}")
-
-    if dry_run:
-        return {"table": table, "md_rows": md_count, "bq_rows": 0, "status": "dry_run"}
-
-    # Export to GCS via DuckDB httpfs
-    log.info(f"  Exporting to {gcs_path}")
-    md_conn.execute("INSTALL httpfs; LOAD httpfs;")
-    md_conn.execute(
-        f"COPY (SELECT * FROM {table}) TO '{gcs_path}' (FORMAT PARQUET, OVERWRITE TRUE)"
-    )
-    log.info(f"  Export complete")
-
-    # Load from GCS into BigQuery
-    log.info(f"  Loading into {bq_table_ref}")
-    job_config = bigquery.LoadJobConfig(
-        source_format=bigquery.SourceFormat.PARQUET,
-        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-        autodetect=True,
-    )
-    load_job = bq_client.load_table_from_uri(
-        gcs_path,
-        bq_table_ref,
-        job_config=job_config,
-    )
-    load_job.result()
-    log.info(f"  Load complete")
-
-    bq_table = bq_client.get_table(bq_table_ref)
-    bq_count = bq_table.num_rows
-    log.info(f"  BigQuery rows: {bq_count:,}")
-
-    # Clean up GCS staging files
-    storage_client = storage.Client()
-    bucket = storage_client.bucket(gcs_bucket)
-    prefix = f"migration/{timestamp}/{table}/"
-    blobs = list(bucket.list_blobs(prefix=prefix))
-    for blob in blobs:
-        blob.delete()
-    log.info(f"  Cleaned up {len(blobs)} staging files from GCS")
-
-    return {
-        "table": table,
-        "md_rows": md_count,
-        "bq_rows": bq_count,
-        "status": "ok" if md_count == bq_count else "row_count_mismatch",
-    }
-
-
-def migrate_table_direct(
+def migrate_table(
     md_conn,
     bq_client,
     table: str,
@@ -190,8 +96,7 @@ def migrate_table_direct(
     dataset: str,
     dry_run: bool = False,
 ) -> dict:
-    """Load table directly from MotherDuck into BigQuery via in-memory Pandas."""
-    import polars as pl
+    """Load table directly from MotherDuck into BigQuery via in-memory Arrow."""
     from google.cloud import bigquery
 
     bq_table_ref = f"{project}.{dataset}.{table}"
@@ -201,92 +106,91 @@ def migrate_table_direct(
     if dry_run:
         return {"table": table, "md_rows": md_count, "bq_rows": 0, "status": "dry_run"}
 
-    df = md_conn.execute(f"SELECT * FROM {table}").pl()
+    df = md_conn.execute(f"SELECT * FROM {table}").df()
     log.info(f"  Loaded {len(df):,} rows into memory")
 
     job_config = bigquery.LoadJobConfig(
         write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
         autodetect=True,
     )
-    bq_client.load_table_from_dataframe(
-        df.to_pandas(), bq_table_ref, job_config=job_config
-    ).result()
+    bq_client.load_table_from_dataframe(df, bq_table_ref, job_config=job_config).result()
 
     bq_table = bq_client.get_table(bq_table_ref)
     bq_count = bq_table.num_rows
     log.info(f"  BigQuery rows: {bq_count:,}")
 
-    return {
-        "table": table,
-        "md_rows": md_count,
-        "bq_rows": bq_count,
-        "status": "ok" if md_count == bq_count else "row_count_mismatch",
-    }
+    status = "ok" if md_count == bq_count else "row_count_mismatch"
+    return {"table": table, "md_rows": md_count, "bq_rows": bq_count, "status": status}
 
 
 def main():
     parser = argparse.ArgumentParser(description="Migrate MotherDuck tables to BigQuery")
-    parser.add_argument("--tables", nargs="*", help="Specific tables to migrate (default: all)")
+    parser.add_argument(
+        "--database",
+        default=os.environ.get("MOTHERDUCK_DATABASE", "econ_agent"),
+        help="MotherDuck source database (default: econ_agent)",
+    )
+    parser.add_argument(
+        "--schema",
+        default=os.environ.get("MOTHERDUCK_PROD_SCHEMA", "main"),
+        help="MotherDuck source schema (default: main)",
+    )
+    parser.add_argument("--tables", nargs="*", help="Specific tables to migrate (default: all non-empty)")
+    parser.add_argument("--include-empty", action="store_true", help="Also migrate empty tables")
     parser.add_argument("--dry-run", action="store_true", help="Print plan without migrating")
-    parser.add_argument("--direct", action="store_true", help="Load directly without GCS staging")
-    parser.add_argument("--dataset", default=os.environ.get("BIGQUERY_DATASET", "economics_raw"))
+    parser.add_argument(
+        "--dataset",
+        default=os.environ.get("BIGQUERY_DATASET", "economics_raw"),
+        help="Target BigQuery dataset (default: economics_raw)",
+    )
     args = parser.parse_args()
 
     project = os.environ.get("BIGQUERY_PROJECT")
-    gcs_bucket = os.environ.get("GCS_BUCKET_NAME")
-
     if not project:
         log.error("BIGQUERY_PROJECT environment variable not set")
         sys.exit(1)
-    if not args.direct and not gcs_bucket:
-        log.error("GCS_BUCKET_NAME not set. Use --direct to skip GCS staging.")
-        sys.exit(1)
 
-    md_conn = get_motherduck_connection()
+    md_conn = get_motherduck_connection(args.database)
     bq_client = get_bq_client()
 
-    available_tables = list_existing_tables(md_conn)
-    tables_to_migrate = args.tables if args.tables else RAW_TABLES
+    available = list_tables(md_conn, database=args.database, schema=args.schema, include_empty=args.include_empty)
 
-    # Filter to tables that actually exist in MotherDuck
-    tables_to_migrate = [t for t in tables_to_migrate if t in available_tables]
-    missing = [t for t in (args.tables or RAW_TABLES) if t not in available_tables]
-    if missing:
-        log.warning(f"Tables not found in MotherDuck (will skip): {missing}")
+    if args.tables:
+        tables_to_migrate = [t for t in args.tables if t in available]
+        missing = [t for t in args.tables if t not in available]
+        if missing:
+            log.warning(f"Tables not found in MotherDuck (skipping): {missing}")
+    else:
+        tables_to_migrate = available
 
     log.info(f"{'DRY RUN: ' if args.dry_run else ''}Migrating {len(tables_to_migrate)} tables")
-    log.info(f"  Source: MotherDuck → Target: {project}.{args.dataset}")
+    log.info(f"  Source: MotherDuck {args.database}.{args.schema}")
+    log.info(f"  Target: {project}.{args.dataset}")
 
     results = []
     for table in tables_to_migrate:
         log.info(f"\nMigrating: {table}")
         try:
-            if args.direct:
-                result = migrate_table_direct(
-                    md_conn, bq_client, table, project, args.dataset, args.dry_run
-                )
-            else:
-                result = migrate_table_via_gcs(
-                    md_conn, bq_client, table, project, args.dataset, gcs_bucket, args.dry_run
-                )
+            result = migrate_table(
+                md_conn, bq_client, table, project, args.dataset, args.dry_run
+            )
         except Exception as e:
             log.error(f"  FAILED: {e}")
             result = {"table": table, "md_rows": -1, "bq_rows": -1, "status": f"error: {e}"}
         results.append(result)
 
-    # Print reconciliation summary
-    print("\n" + "=" * 60)
-    print("MIGRATION RECONCILIATION REPORT")
-    print("=" * 60)
-    print(f"{'Table':<40} {'MD Rows':>10} {'BQ Rows':>10} {'Status'}")
-    print("-" * 70)
+    print("\n" + "=" * 70)
+    print("MIGRATION REPORT")
+    print(f"Source: MotherDuck {args.database} -> Target: {project}.{args.dataset}")
+    print("=" * 70)
+    print(f"{'Table':<45} {'MD Rows':>10} {'BQ Rows':>10} {'Status'}")
+    print("-" * 75)
     ok_count = 0
     for r in results:
-        status = r["status"]
-        if status == "ok":
+        if r["status"] == "ok":
             ok_count += 1
-        print(f"{r['table']:<40} {r['md_rows']:>10,} {r['bq_rows']:>10,} {status}")
-    print("-" * 70)
+        print(f"{r['table']:<45} {r['md_rows']:>10,} {r['bq_rows']:>10,} {r['status']}")
+    print("-" * 75)
     print(f"\nCompleted: {ok_count}/{len(results)} tables migrated successfully")
 
     if any(r["status"] not in ("ok", "dry_run") for r in results):

--- a/scripts/reconcile_migration.py
+++ b/scripts/reconcile_migration.py
@@ -1,10 +1,9 @@
-"""Compare row counts between MotherDuck and BigQuery after migration.
-
-Phase 4 reconciliation (issue #79).
+"""Compare row counts between MotherDuck and BigQuery and surface data gaps.
 
 Usage:
     uv run python scripts/reconcile_migration.py
-    uv run python scripts/reconcile_migration.py --tables sp500_companies_raw fred_series_raw
+    uv run python scripts/reconcile_migration.py --database econ_agent
+    uv run python scripts/reconcile_migration.py --dataset economics_raw
     uv run python scripts/reconcile_migration.py --tolerance 0.01  # allow 1% discrepancy
 """
 
@@ -16,12 +15,19 @@ import sys
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 log = logging.getLogger(__name__)
 
-from scripts.migrate_motherduck_to_bq import RAW_TABLES
-
 
 def main():
     parser = argparse.ArgumentParser(description="Reconcile MotherDuck vs BigQuery row counts")
-    parser.add_argument("--tables", nargs="*")
+    parser.add_argument(
+        "--database",
+        default=os.environ.get("MOTHERDUCK_DATABASE", "econ_agent"),
+        help="MotherDuck source database (default: econ_agent)",
+    )
+    parser.add_argument(
+        "--schema",
+        default=os.environ.get("MOTHERDUCK_PROD_SCHEMA", "main"),
+    )
+    parser.add_argument("--tables", nargs="*", help="Specific tables to check (default: all non-empty MD tables)")
     parser.add_argument("--tolerance", type=float, default=0.0,
                         help="Fractional row count tolerance (default: 0 = exact match)")
     parser.add_argument("--dataset", default=os.environ.get("BIGQUERY_DATASET", "economics_raw"))
@@ -35,8 +41,7 @@ def main():
     try:
         import duckdb
         token = os.environ.get("MOTHERDUCK_TOKEN")
-        database = os.environ.get("MOTHERDUCK_DATABASE", "my_db")
-        md_conn = duckdb.connect(f"md:{database}?motherduck_token={token}")
+        md_conn = duckdb.connect(f"md:{args.database}?motherduck_token={token}")
     except Exception as e:
         log.error(f"Failed to connect to MotherDuck: {e}")
         sys.exit(1)
@@ -44,23 +49,50 @@ def main():
     from google.cloud import bigquery
     bq_client = bigquery.Client(project=project)
 
-    tables = args.tables or RAW_TABLES
-    results = []
+    # Get all non-empty tables from MotherDuck
+    if args.tables:
+        md_tables = set(args.tables)
+    else:
+        rows = md_conn.execute(
+            f"""
+            SELECT t.table_name
+            FROM information_schema.tables t
+            JOIN duckdb_tables() d ON d.table_name = t.table_name AND d.schema_name = t.table_schema
+            WHERE t.table_schema = '{args.schema}' AND t.table_type = 'BASE TABLE'
+            AND d.estimated_size > 0
+            ORDER BY d.estimated_size DESC
+            """
+        ).fetchall()
+        md_tables = {r[0] for r in rows}
 
-    for table in tables:
+    # Get all tables in the target BQ dataset
+    try:
+        bq_tables = {t.table_id for t in bq_client.list_tables(f"{project}.{args.dataset}")}
+    except Exception:
+        bq_tables = set()
+
+    all_tables = md_tables | bq_tables
+
+    results = []
+    for table in sorted(all_tables):
         md_count = -1
         bq_count = -1
-        try:
-            row = md_conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
-            md_count = row[0] if row else 0
-        except Exception as e:
-            log.warning(f"{table}: MotherDuck error — {e}")
+        in_md = table in md_tables
+        in_bq = table in bq_tables
 
-        try:
-            bq_table = bq_client.get_table(f"{project}.{args.dataset}.{table}")
-            bq_count = bq_table.num_rows
-        except Exception as e:
-            log.warning(f"{table}: BigQuery error — {e}")
+        if in_md:
+            try:
+                row = md_conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+                md_count = row[0] if row else 0
+            except Exception as e:
+                log.warning(f"{table}: MotherDuck error — {e}")
+
+        if in_bq:
+            try:
+                bq_table = bq_client.get_table(f"{project}.{args.dataset}.{table}")
+                bq_count = bq_table.num_rows
+            except Exception as e:
+                log.warning(f"{table}: BigQuery error — {e}")
 
         if md_count >= 0 and bq_count >= 0:
             if md_count == 0:
@@ -75,25 +107,56 @@ def main():
             "table": table,
             "md_rows": md_count,
             "bq_rows": bq_count,
+            "in_md": in_md,
+            "in_bq": in_bq,
             "match": match,
         })
 
-    print("\n" + "=" * 70)
-    print("RECONCILIATION REPORT")
-    print(f"Source: MotherDuck | Target: {project}.{args.dataset}")
-    print("=" * 70)
-    print(f"{'Table':<40} {'MD Rows':>10} {'BQ Rows':>10} {'Match'}")
-    print("-" * 70)
+    # Categorize
+    matched = [r for r in results if r["match"]]
+    mismatched = [r for r in results if r["in_md"] and r["in_bq"] and not r["match"]]
+    md_only = [r for r in results if r["in_md"] and not r["in_bq"]]
+    bq_only = [r for r in results if r["in_bq"] and not r["in_md"]]
 
-    ok = sum(1 for r in results if r["match"])
-    for r in results:
-        flag = "✓" if r["match"] else "✗ MISMATCH"
-        print(f"{r['table']:<40} {r['md_rows']:>10,} {r['bq_rows']:>10,} {flag}")
+    print("\n" + "=" * 75)
+    print("MIGRATION RECONCILIATION REPORT")
+    print(f"Source: MotherDuck {args.database} | Target: {project}.{args.dataset}")
+    print("=" * 75)
 
-    print("-" * 70)
-    print(f"\n{ok}/{len(results)} tables match")
+    if matched:
+        print(f"\nMATCHED ({len(matched)} tables)")
+        print(f"  {'Table':<45} {'MD Rows':>10} {'BQ Rows':>10}")
+        print("  " + "-" * 67)
+        for r in matched:
+            print(f"  {r['table']:<45} {r['md_rows']:>10,} {r['bq_rows']:>10,}")
 
-    if ok < len(results):
+    if mismatched:
+        print(f"\nMISMATCHED ({len(mismatched)} tables)")
+        print(f"  {'Table':<45} {'MD Rows':>10} {'BQ Rows':>10} {'Diff':>10}")
+        print("  " + "-" * 77)
+        for r in mismatched:
+            diff = r['bq_rows'] - r['md_rows']
+            print(f"  {r['table']:<45} {r['md_rows']:>10,} {r['bq_rows']:>10,} {diff:>+10,}")
+
+    if md_only:
+        print(f"\nGAPS - in MotherDuck only, not yet in BigQuery ({len(md_only)} tables)")
+        print(f"  {'Table':<45} {'MD Rows':>10}")
+        print("  " + "-" * 57)
+        for r in md_only:
+            print(f"  {r['table']:<45} {r['md_rows']:>10,}")
+
+    if bq_only:
+        print(f"\nBQ ONLY - in BigQuery only, not in MotherDuck ({len(bq_only)} tables)")
+        print(f"  {'Table':<45} {'BQ Rows':>10}")
+        print("  " + "-" * 57)
+        for r in bq_only:
+            print(f"  {r['table']:<45} {r['bq_rows']:>10,}")
+
+    print("\n" + "=" * 75)
+    print(f"Summary: {len(matched)} matched | {len(mismatched)} mismatched | "
+          f"{len(md_only)} MD-only gaps | {len(bq_only)} BQ-only")
+
+    if mismatched or md_only:
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `RAW_TABLES` list with dynamic table discovery from MotherDuck
- Filter by `database_name` in the query to prevent cross-database duplicates (was seeing 156 tables instead of 100)
- Add `--database` and `--schema` CLI args defaulting to `econ_agent`/`main`
- `reconcile_migration.py` now compares all non-empty MD tables against BQ and categorizes output into matched / mismatched / MD-only gaps / BQ-only
- Remove unicode symbols that caused `cp1252` encoding errors on Windows

## Result
Successfully migrated 100/100 tables from `econ_agent` to `economics_raw` in BigQuery with exact row count matches. Three tables identified as vestigial (`fred_data_raw`, `country_map_data`, `latest_state_data` in `prod_econ`) — no active Dagster assets reference them.

## Test plan
- [x] Dry run confirmed 100 tables with correct row counts
- [x] Full migration ran: 100/100 ok
- [x] Reconciliation report: 100 matched, 0 mismatched, 4 gaps (3 vestigial prod_econ tables + 1 empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)