### PR TITLE
feat: MetricFlow semantic layer for financial and economic metrics (#85)

### DIFF
--- a/dbt_project/.gitignore
+++ b/dbt_project/.gitignore
@@ -2,3 +2,4 @@
 /logs
 .user.yml
 /dbt_packages
+dbt_internal_packages/

--- a/dbt_project/dbt_project.yml
+++ b/dbt_project/dbt_project.yml
@@ -40,6 +40,9 @@ models:
     signals:
       +schema: economics_signals
       +materialized: table
+    semantic_layer:
+      +schema: economics_marts
+      +materialized: table
     agents_preprocess:
       +schema: economics_analysis
       +materialized: view

--- a/dbt_project/models/commodities/semantic_models.yml
+++ b/dbt_project/models/commodities/semantic_models.yml
@@ -7,6 +7,8 @@ semantic_models:
       (e.g. crude oil, natural gas, copper, aluminum).
       Grain: one row per commodity per unit per trading day.
     model: ref('input_commodities_analysis_return')
+    defaults:
+      agg_time_dimension: trade_date
     entities:
       - name: commodity
         type: primary
@@ -49,6 +51,8 @@ semantic_models:
       (crude oil, natural gas, gasoline, heating oil).
       Grain: one row per commodity per unit per trading day.
     model: ref('energy_commodities_analysis_return')
+    defaults:
+      agg_time_dimension: trade_date
     entities:
       - name: energy_commodity
         type: primary
@@ -80,6 +84,8 @@ semantic_models:
       (corn, wheat, soybeans, etc.).
       Grain: one row per commodity per unit per trading day.
     model: ref('agriculture_commodities_analysis_return')
+    defaults:
+      agg_time_dimension: trade_date
     entities:
       - name: agri_commodity
         type: primary

--- a/dbt_project/models/commodities/semantic_models.yml
+++ b/dbt_project/models/commodities/semantic_models.yml
@@ -1,0 +1,106 @@
+version: 2
+
+semantic_models:
+  - name: commodity_daily_prices
+    description: >
+      Daily spot prices and rolling returns for industrial/input commodities
+      (e.g. crude oil, natural gas, copper, aluminum).
+      Grain: one row per commodity per unit per trading day.
+    model: ref('input_commodities_analysis_return')
+    entities:
+      - name: commodity
+        type: primary
+        expr: "commodity_name || '|' || commodity_unit"
+    dimensions:
+      - name: trade_date
+        type: time
+        type_params:
+          time_granularity: day
+        expr: date
+      - name: commodity_name
+        type: categorical
+      - name: commodity_unit
+        type: categorical
+    measures:
+      - name: spot_price
+        agg: max
+        expr: current_price
+        description: Daily spot price in commodity_unit terms
+      - name: commodity_return_1mo
+        agg: average
+        expr: pct_change_1mo
+      - name: commodity_return_3mo
+        agg: average
+        expr: pct_change_3mo
+      - name: commodity_return_6mo
+        agg: average
+        expr: pct_change_6mo
+      - name: commodity_return_1yr
+        agg: average
+        expr: pct_change_1yr
+      - name: commodity_price_std_1yr
+        agg: average
+        expr: std_diff_1yr
+        description: 1-year standard deviation of daily price changes
+
+  - name: energy_commodity_prices
+    description: >
+      Daily spot prices and rolling returns for energy commodities
+      (crude oil, natural gas, gasoline, heating oil).
+      Grain: one row per commodity per unit per trading day.
+    model: ref('energy_commodities_analysis_return')
+    entities:
+      - name: energy_commodity
+        type: primary
+        expr: "commodity_name || '|' || commodity_unit"
+    dimensions:
+      - name: trade_date
+        type: time
+        type_params:
+          time_granularity: day
+        expr: date
+      - name: commodity_name
+        type: categorical
+      - name: commodity_unit
+        type: categorical
+    measures:
+      - name: energy_spot_price
+        agg: max
+        expr: current_price
+      - name: energy_return_1mo
+        agg: average
+        expr: pct_change_1mo
+      - name: energy_return_1yr
+        agg: average
+        expr: pct_change_1yr
+
+  - name: agriculture_commodity_prices
+    description: >
+      Daily spot prices and rolling returns for agricultural commodities
+      (corn, wheat, soybeans, etc.).
+      Grain: one row per commodity per unit per trading day.
+    model: ref('agriculture_commodities_analysis_return')
+    entities:
+      - name: agri_commodity
+        type: primary
+        expr: "commodity_name || '|' || commodity_unit"
+    dimensions:
+      - name: trade_date
+        type: time
+        type_params:
+          time_granularity: day
+        expr: date
+      - name: commodity_name
+        type: categorical
+      - name: commodity_unit
+        type: categorical
+    measures:
+      - name: agri_spot_price
+        agg: max
+        expr: current_price
+      - name: agri_return_1mo
+        agg: average
+        expr: pct_change_1mo
+      - name: agri_return_1yr
+        agg: average
+        expr: pct_change_1yr

--- a/dbt_project/models/government/semantic_models.yml
+++ b/dbt_project/models/government/semantic_models.yml
@@ -8,6 +8,8 @@ semantic_models:
       Covers: GDP, CPI, PCE, unemployment rate, Fed funds rate, housing starts,
       industrial production, and 100+ other macro series.
     model: ref('fred_monthly_diff')
+    defaults:
+      agg_time_dimension: observation_date
     entities:
       - name: fred_series
         type: primary

--- a/dbt_project/models/government/semantic_models.yml
+++ b/dbt_project/models/government/semantic_models.yml
@@ -1,0 +1,40 @@
+version: 2
+
+semantic_models:
+  - name: economic_indicators
+    description: >
+      Monthly FRED economic indicator values with period-over-period change.
+      Grain: one row per series_code per month.
+      Covers: GDP, CPI, PCE, unemployment rate, Fed funds rate, housing starts,
+      industrial production, and 100+ other macro series.
+    model: ref('fred_monthly_diff')
+    entities:
+      - name: fred_series
+        type: primary
+        expr: "series_code || '|' || CAST(date AS VARCHAR)"
+    dimensions:
+      - name: observation_date
+        type: time
+        type_params:
+          time_granularity: month
+        expr: date
+      - name: series_code
+        type: categorical
+        description: FRED series identifier (e.g. UNRATE, FEDFUNDS, CPIAUCSL)
+      - name: series_name
+        type: categorical
+        description: Human-readable series name
+      - name: data_source
+        type: categorical
+    measures:
+      - name: indicator_value
+        agg: max
+        expr: value
+        description: Series value for the observation period
+      - name: indicator_mom_change
+        agg: max
+        expr: period_diff
+        description: Absolute month-over-month change in indicator value
+      - name: series_count
+        agg: count_distinct
+        expr: series_code

--- a/dbt_project/models/markets/semantic_models.yml
+++ b/dbt_project/models/markets/semantic_models.yml
@@ -6,6 +6,8 @@ semantic_models:
       Daily OHLCV price data and rolling returns for S&P 500 companies.
       Grain: one row per symbol per exchange per trading day.
     model: ref('sp500_companies_analysis_return')
+    defaults:
+      agg_time_dimension: trade_date
     entities:
       - name: stock
         type: primary
@@ -70,6 +72,8 @@ semantic_models:
       Daily OHLCV price data and rolling returns for US sector ETFs.
       Grain: one row per sector symbol per exchange per trading day.
     model: ref('us_sector_analysis_return')
+    defaults:
+      agg_time_dimension: trade_date
     entities:
       - name: sector_etf
         type: primary
@@ -109,6 +113,8 @@ semantic_models:
       Daily forex exchange rates and rolling returns.
       Grain: one row per currency pair per trading day.
     model: ref('currency_analysis_return')
+    defaults:
+      agg_time_dimension: trade_date
     entities:
       - name: currency_pair
         type: primary
@@ -139,6 +145,8 @@ semantic_models:
       Daily price data and rolling returns for fixed income instruments (bonds, Treasuries).
       Grain: one row per symbol per exchange per trading day.
     model: ref('fixed_income_analysis_return')
+    defaults:
+      agg_time_dimension: trade_date
     entities:
       - name: bond_instrument
         type: primary

--- a/dbt_project/models/markets/semantic_models.yml
+++ b/dbt_project/models/markets/semantic_models.yml
@@ -1,0 +1,168 @@
+version: 2
+
+semantic_models:
+  - name: market_daily_prices
+    description: >
+      Daily OHLCV price data and rolling returns for S&P 500 companies.
+      Grain: one row per symbol per exchange per trading day.
+    model: ref('sp500_companies_analysis_return')
+    entities:
+      - name: stock
+        type: primary
+        expr: "symbol || '|' || exchange"
+    dimensions:
+      - name: trade_date
+        type: time
+        type_params:
+          time_granularity: day
+        expr: date
+      - name: symbol
+        type: categorical
+      - name: exchange
+        type: categorical
+    measures:
+      - name: close_price
+        agg: max
+        expr: current_price
+        description: Daily closing price
+      - name: high_price
+        agg: max
+        expr: current_high
+      - name: low_price
+        agg: min
+        expr: current_low
+      - name: share_volume
+        agg: sum
+        expr: current_volume
+      - name: daily_price_change
+        agg: average
+        expr: daily_diff
+        description: Dollar change from prior close
+      - name: return_1mo
+        agg: average
+        expr: pct_change_1mo
+        description: 1-month percent price return
+      - name: return_3mo
+        agg: average
+        expr: pct_change_3mo
+      - name: return_6mo
+        agg: average
+        expr: pct_change_6mo
+      - name: return_9mo
+        agg: average
+        expr: pct_change_9mo
+      - name: return_1yr
+        agg: average
+        expr: pct_change_1yr
+        description: 1-year percent price return
+      - name: price_std_1yr
+        agg: average
+        expr: std_diff_1yr
+        description: >
+          1-year standard deviation of daily dollar price changes.
+          Divide by close_price to get a dimensionless volatility estimate.
+      - name: symbol_count
+        agg: count_distinct
+        expr: symbol
+
+  - name: sector_daily_performance
+    description: >
+      Daily OHLCV price data and rolling returns for US sector ETFs.
+      Grain: one row per sector symbol per exchange per trading day.
+    model: ref('us_sector_analysis_return')
+    entities:
+      - name: sector_etf
+        type: primary
+        expr: "symbol || '|' || exchange"
+    dimensions:
+      - name: trade_date
+        type: time
+        type_params:
+          time_granularity: day
+        expr: date
+      - name: symbol
+        type: categorical
+      - name: exchange
+        type: categorical
+    measures:
+      - name: sector_close_price
+        agg: max
+        expr: current_price
+      - name: sector_volume
+        agg: sum
+        expr: current_volume
+      - name: sector_return_1mo
+        agg: average
+        expr: pct_change_1mo
+      - name: sector_return_3mo
+        agg: average
+        expr: pct_change_3mo
+      - name: sector_return_1yr
+        agg: average
+        expr: pct_change_1yr
+      - name: sector_price_std_1yr
+        agg: average
+        expr: std_diff_1yr
+
+  - name: currency_daily_rates
+    description: >
+      Daily forex exchange rates and rolling returns.
+      Grain: one row per currency pair per trading day.
+    model: ref('currency_analysis_return')
+    entities:
+      - name: currency_pair
+        type: primary
+        expr: "symbol || '|' || exchange"
+    dimensions:
+      - name: trade_date
+        type: time
+        type_params:
+          time_granularity: day
+        expr: date
+      - name: symbol
+        type: categorical
+      - name: exchange
+        type: categorical
+    measures:
+      - name: fx_rate
+        agg: max
+        expr: current_price
+      - name: fx_return_1mo
+        agg: average
+        expr: pct_change_1mo
+      - name: fx_return_1yr
+        agg: average
+        expr: pct_change_1yr
+
+  - name: fixed_income_daily_prices
+    description: >
+      Daily price data and rolling returns for fixed income instruments (bonds, Treasuries).
+      Grain: one row per symbol per exchange per trading day.
+    model: ref('fixed_income_analysis_return')
+    entities:
+      - name: bond_instrument
+        type: primary
+        expr: "symbol || '|' || exchange"
+    dimensions:
+      - name: trade_date
+        type: time
+        type_params:
+          time_granularity: day
+        expr: date
+      - name: symbol
+        type: categorical
+      - name: exchange
+        type: categorical
+    measures:
+      - name: bond_price
+        agg: max
+        expr: current_price
+      - name: bond_return_1mo
+        agg: average
+        expr: pct_change_1mo
+      - name: bond_return_1yr
+        agg: average
+        expr: pct_change_1yr
+      - name: bond_price_std_1yr
+        agg: average
+        expr: std_diff_1yr

--- a/dbt_project/models/metrics.yml
+++ b/dbt_project/models/metrics.yml
@@ -1,0 +1,353 @@
+version: 2
+
+metrics:
+
+  # ============================================================
+  # EQUITY MARKET METRICS
+  # ============================================================
+
+  - name: avg_close_price
+    label: Average Close Price
+    description: Average daily closing price across selected symbols and time range.
+    type: simple
+    type_params:
+      measure:
+        name: close_price
+        fill_nulls_with: 0
+
+  - name: total_volume
+    label: Total Trading Volume
+    description: Total share volume traded across selected symbols and time range.
+    type: simple
+    type_params:
+      measure:
+        name: share_volume
+
+  - name: avg_return_1mo
+    label: Avg 1-Month Return (%)
+    description: >
+      Average 1-month trailing price return (%). Reflects the mean of each
+      symbol's 1-month lookback return across selected dates.
+    type: simple
+    type_params:
+      measure:
+        name: return_1mo
+
+  - name: avg_return_3mo
+    label: Avg 3-Month Return (%)
+    description: Average 3-month trailing price return (%).
+    type: simple
+    type_params:
+      measure:
+        name: return_3mo
+
+  - name: avg_return_6mo
+    label: Avg 6-Month Return (%)
+    description: Average 6-month trailing price return (%).
+    type: simple
+    type_params:
+      measure:
+        name: return_6mo
+
+  - name: avg_return_1yr
+    label: Avg 1-Year Return (%)
+    description: >
+      Average 1-year trailing price return (%). Common baseline for annual
+      performance comparisons (not annualized — reflects actual 12m return).
+    type: simple
+    type_params:
+      measure:
+        name: return_1yr
+
+  - name: price_volatility_proxy
+    label: Price Volatility (1-Year StdDev)
+    description: >
+      Average 1-year standard deviation of daily dollar price changes.
+      Higher = more price dispersion. For a normalized volatility ratio,
+      see annualized_volatility_ratio.
+    type: simple
+    type_params:
+      measure:
+        name: price_std_1yr
+
+  - name: annualized_volatility_ratio
+    label: Annualized Volatility Ratio
+    description: >
+      Ratio of 1-year price StdDev to close price — a dimensionless proxy for
+      annualized volatility (analogous to daily vol * sqrt(252) / price).
+      Higher = more volatile relative to price level.
+    type: ratio
+    type_params:
+      numerator:
+        name: price_volatility_proxy
+      denominator:
+        name: avg_close_price
+
+  - name: unique_symbols
+    label: Distinct Symbols
+    description: Count of distinct ticker symbols in the selection.
+    type: simple
+    type_params:
+      measure:
+        name: symbol_count
+
+  # ============================================================
+  # SECTOR METRICS
+  # ============================================================
+
+  - name: sector_avg_return_1yr
+    label: Sector Avg 1-Year Return (%)
+    description: Average 1-year trailing return across sector ETFs.
+    type: simple
+    type_params:
+      measure:
+        name: sector_return_1yr
+
+  - name: sector_avg_return_1mo
+    label: Sector Avg 1-Month Return (%)
+    description: Average 1-month trailing return across sector ETFs.
+    type: simple
+    type_params:
+      measure:
+        name: sector_return_1mo
+
+  - name: sector_volatility_proxy
+    label: Sector Price Volatility (1-Year StdDev)
+    description: Average 1-year standard deviation of daily price changes for sector ETFs.
+    type: simple
+    type_params:
+      measure:
+        name: sector_price_std_1yr
+
+  # ============================================================
+  # COMMODITY METRICS
+  # ============================================================
+
+  - name: commodity_spot_price
+    label: Commodity Spot Price
+    description: Daily spot price for the selected commodity.
+    type: simple
+    type_params:
+      measure:
+        name: spot_price
+
+  - name: commodity_return_1mo
+    label: Commodity 1-Month Return (%)
+    description: 1-month trailing return for commodities.
+    type: simple
+    type_params:
+      measure:
+        name: commodity_return_1mo
+
+  - name: commodity_return_1yr
+    label: Commodity 1-Year Return (%)
+    description: 1-year trailing return for commodities.
+    type: simple
+    type_params:
+      measure:
+        name: commodity_return_1yr
+
+  - name: energy_return_1yr
+    label: Energy Commodity 1-Year Return (%)
+    description: 1-year trailing return for energy commodities.
+    type: simple
+    type_params:
+      measure:
+        name: energy_return_1yr
+
+  - name: agri_return_1yr
+    label: Agricultural Commodity 1-Year Return (%)
+    description: 1-year trailing return for agricultural commodities.
+    type: simple
+    type_params:
+      measure:
+        name: agri_return_1yr
+
+  # ============================================================
+  # ECONOMIC INDICATOR METRICS (FRED)
+  # ============================================================
+
+  - name: fred_indicator_value
+    label: FRED Indicator Value
+    description: >
+      Current or most-recent value of a FRED economic series.
+      Group by series_code or series_name to compare multiple indicators.
+    type: simple
+    type_params:
+      measure:
+        name: indicator_value
+
+  - name: fred_mom_change
+    label: FRED Month-over-Month Change
+    description: >
+      Absolute month-over-month change in FRED indicator value.
+      Positive = rising, negative = falling.
+    type: simple
+    type_params:
+      measure:
+        name: indicator_mom_change
+
+  # ============================================================
+  # INFLATION METRICS
+  # ============================================================
+
+  - name: cpi_yoy
+    label: CPI Year-over-Year (%)
+    description: Consumer Price Index year-over-year percent change. Core inflation gauge.
+    type: simple
+    type_params:
+      measure:
+        name: cpi_12m_yoy
+
+  - name: cpi_3m_annualized
+    label: CPI 3-Month Annualized (%)
+    description: >
+      CPI 3-month annualized rate — a forward-looking inflation momentum signal.
+      When above cpi_yoy, inflation is re-accelerating.
+    type: simple
+    type_params:
+      measure:
+        name: cpi_3m_annualized
+
+  - name: inflation_momentum
+    label: CPI Momentum Spread
+    description: >
+      3-month annualized CPI minus 12-month YoY CPI. Positive = re-accelerating
+      inflation pressure. Negative = inflation decelerating.
+    type: simple
+    type_params:
+      measure:
+        name: cpi_momentum_spread
+
+  - name: core_pce_yoy
+    label: Core PCE Year-over-Year (%)
+    description: >
+      Core Personal Consumption Expenditures year-over-year change (%).
+      The Federal Reserve's preferred inflation gauge (2% target).
+    type: simple
+    type_params:
+      measure:
+        name: core_pce_yoy
+
+  - name: pce_above_target
+    label: PCE Deviation from 2% Target
+    description: >
+      Core PCE minus 2% Fed target. Positive = above target (hawkish signal),
+      negative = below target (dovish signal).
+    type: simple
+    type_params:
+      measure:
+        name: pce_vs_target
+
+  - name: breakeven_inflation_5y
+    label: 5-Year Breakeven Inflation Rate (%)
+    description: >
+      Market-implied 5-year inflation expectation from TIPS breakeven.
+      Reflects bond market inflation pricing over the near-term horizon.
+    type: simple
+    type_params:
+      measure:
+        name: breakeven_5y
+
+  - name: breakeven_inflation_10y
+    label: 10-Year Breakeven Inflation Rate (%)
+    description: Market-implied 10-year inflation expectation from TIPS breakeven.
+    type: simple
+    type_params:
+      measure:
+        name: breakeven_10y
+
+  - name: breakeven_term_spread
+    label: 5y/10y Breakeven Spread
+    description: >
+      5-year minus 10-year breakeven spread. Positive = near-term inflation
+      expectations exceed long-term (front-loaded inflation). Useful for
+      identifying transitory vs. structural inflation regimes.
+    type: simple
+    type_params:
+      measure:
+        name: breakeven_5y_10y_spread
+
+  # ============================================================
+  # LABOR MARKET METRICS
+  # ============================================================
+
+  - name: unemployment_rate
+    label: Unemployment Rate (%)
+    description: Civilian unemployment rate. Fed dual-mandate metric.
+    type: simple
+    type_params:
+      measure:
+        name: unemployment_rate
+
+  - name: labor_market_tightness
+    label: Job Openings / Unemployed Ratio
+    description: >
+      Job openings divided by unemployed workers. > 1.0 = more openings than
+      job seekers (tight market). < 1.0 = labor slack. Fed watches this closely.
+    type: simple
+    type_params:
+      measure:
+        name: jo_unemployed_ratio
+
+  - name: labor_tightness_momentum
+    label: Labor Tightness 3-Month Change
+    description: >
+      3-month change in the job openings / unemployed ratio. Negative = labor
+      market loosening. Key leading indicator for Fed pivot timing.
+    type: simple
+    type_params:
+      measure:
+        name: jo_ratio_3m_change
+
+  - name: sahm_rule_indicator
+    label: Sahm Rule Indicator
+    description: >
+      Sahm Rule recession indicator. Based on 3-month average unemployment rate
+      minus prior 12-month minimum. >= 0.5 historically signals recession onset.
+      Original work: Claudia Sahm, Fed (2019).
+    type: simple
+    type_params:
+      measure:
+        name: sahm_rule
+
+  - name: worker_confidence
+    label: Quits Rate
+    description: >
+      Job quits rate. Higher = workers more confident in finding new jobs
+      (tight market). Declining quits rate signals workers becoming less
+      confident — often leads unemployment rate rises.
+    type: simple
+    type_params:
+      measure:
+        name: quits_rate
+
+  - name: initial_claims
+    label: Average Monthly Initial Claims
+    description: >
+      Average monthly initial unemployment insurance claims. Rising claims
+      are an early warning of labor market deterioration.
+    type: simple
+    type_params:
+      measure:
+        name: avg_monthly_claims
+
+  - name: employment_population_ratio
+    label: Employment-Population Ratio (%)
+    description: >
+      Share of working-age population that is employed. More stable than
+      unemployment rate since it does not move with labor force participation.
+    type: simple
+    type_params:
+      measure:
+        name: employment_ratio
+
+  - name: unrate_3m_momentum
+    label: Unemployment Rate 3-Month Change
+    description: >
+      3-month change in unemployment rate (percentage points). Component of
+      the Sahm Rule calculation. Positive = rising unemployment (deteriorating).
+    type: simple
+    type_params:
+      measure:
+        name: unrate_3m_change

--- a/dbt_project/models/metrics.yml
+++ b/dbt_project/models/metrics.yml
@@ -6,9 +6,11 @@ metrics:
   # EQUITY MARKET METRICS
   # ============================================================
 
-  - name: avg_close_price
-    label: Average Close Price
-    description: Average daily closing price across selected symbols and time range.
+  - name: max_close_price
+    label: Max Close Price
+    description: >
+      Maximum daily closing price across the selected symbols and time range.
+      Group by stock and trade_date for point-in-time close price analysis.
     type: simple
     type_params:
       measure:
@@ -81,7 +83,7 @@ metrics:
       numerator:
         name: price_volatility_proxy
       denominator:
-        name: avg_close_price
+        name: max_close_price
 
   - name: unique_symbols
     label: Distinct Symbols
@@ -118,6 +120,84 @@ metrics:
     type_params:
       measure:
         name: sector_price_std_1yr
+
+  - name: sector_max_close_price
+    label: Sector Max Close Price
+    description: >
+      Maximum daily closing price for sector ETFs across the selected time range.
+      Group by sector ETF and trade_date for point-in-time price analysis.
+    type: simple
+    type_params:
+      measure:
+        name: sector_close_price
+
+  # ============================================================
+  # CURRENCY METRICS
+  # ============================================================
+
+  - name: fx_spot_rate
+    label: FX Spot Rate
+    description: >
+      Maximum daily FX rate across the selected currency pairs and time range.
+      Group by currency pair and trade_date for point-in-time rates.
+    type: simple
+    type_params:
+      measure:
+        name: fx_rate
+
+  - name: fx_return_1mo
+    label: FX 1-Month Return (%)
+    description: Average 1-month trailing return across selected currency pairs.
+    type: simple
+    type_params:
+      measure:
+        name: fx_return_1mo
+
+  - name: fx_return_1yr
+    label: FX 1-Year Return (%)
+    description: Average 1-year trailing return across selected currency pairs.
+    type: simple
+    type_params:
+      measure:
+        name: fx_return_1yr
+
+  # ============================================================
+  # FIXED INCOME METRICS
+  # ============================================================
+
+  - name: bond_max_price
+    label: Fixed Income Max Price
+    description: >
+      Maximum daily price for fixed income instruments across the selected time range.
+      Group by bond instrument and trade_date for point-in-time price analysis.
+    type: simple
+    type_params:
+      measure:
+        name: bond_price
+
+  - name: bond_return_1mo
+    label: Fixed Income 1-Month Return (%)
+    description: Average 1-month trailing return across selected fixed income instruments.
+    type: simple
+    type_params:
+      measure:
+        name: bond_return_1mo
+
+  - name: bond_return_1yr
+    label: Fixed Income 1-Year Return (%)
+    description: Average 1-year trailing return across selected fixed income instruments.
+    type: simple
+    type_params:
+      measure:
+        name: bond_return_1yr
+
+  - name: bond_volatility_proxy
+    label: Fixed Income Price Volatility (1-Year StdDev)
+    description: Average 1-year standard deviation of daily price changes for fixed income instruments.
+    type: simple
+    type_params:
+      measure:
+        name: bond_price_std_1yr
 
   # ============================================================
   # COMMODITY METRICS

--- a/dbt_project/models/saved_queries.yml
+++ b/dbt_project/models/saved_queries.yml
@@ -13,7 +13,7 @@ saved_queries:
         - avg_return_1mo
         - avg_return_6mo
         - avg_return_1yr
-        - avg_close_price
+        - max_close_price
         - annualized_volatility_ratio
       group_by:
         - "Dimension('stock__symbol')"
@@ -29,8 +29,38 @@ saved_queries:
         - sector_avg_return_1mo
         - sector_avg_return_1yr
         - sector_volatility_proxy
+        - sector_max_close_price
       group_by:
         - "Dimension('sector_etf__symbol')"
+
+  - name: currency_performance_by_pair
+    label: Currency Performance by Pair
+    description: >
+      Spot rate plus 1-month and 1-year FX returns for each currency pair.
+      Useful for dollar strength, carry proxy, and cross-asset macro checks.
+    query_params:
+      metrics:
+        - fx_spot_rate
+        - fx_return_1mo
+        - fx_return_1yr
+      group_by:
+        - "Dimension('currency_pair__symbol')"
+        - "Dimension('currency_pair__exchange')"
+
+  - name: fixed_income_performance_by_instrument
+    label: Fixed Income Performance by Instrument
+    description: >
+      Price, 1-month return, 1-year return, and volatility proxy for fixed income
+      instruments. Useful for duration, rates, and risk-off regime analysis.
+    query_params:
+      metrics:
+        - bond_max_price
+        - bond_return_1mo
+        - bond_return_1yr
+        - bond_volatility_proxy
+      group_by:
+        - "Dimension('bond_instrument__symbol')"
+        - "Dimension('bond_instrument__exchange')"
 
   - name: inflation_dashboard
     label: Inflation Dashboard

--- a/dbt_project/models/saved_queries.yml
+++ b/dbt_project/models/saved_queries.yml
@@ -1,0 +1,99 @@
+version: 2
+
+saved_queries:
+
+  - name: equity_performance_by_symbol
+    label: Equity Performance by Symbol
+    description: >
+      1-month, 6-month, and 1-year trailing returns for each S&P 500 symbol
+      as of the most recent trading day. Use this to rank stocks by momentum
+      or identify outlier performers.
+    query_params:
+      metrics:
+        - avg_return_1mo
+        - avg_return_6mo
+        - avg_return_1yr
+        - avg_close_price
+        - annualized_volatility_ratio
+      group_by:
+        - "Dimension('stock__symbol')"
+        - "Dimension('stock__exchange')"
+
+  - name: sector_relative_performance
+    label: Sector Relative Performance
+    description: >
+      1-month and 1-year returns for US sector ETFs. Useful for sector
+      rotation analysis — which sectors are leading/lagging the broad market?
+    query_params:
+      metrics:
+        - sector_avg_return_1mo
+        - sector_avg_return_1yr
+        - sector_volatility_proxy
+      group_by:
+        - "Dimension('sector_etf__symbol')"
+
+  - name: inflation_dashboard
+    label: Inflation Dashboard
+    description: >
+      Monthly CPI, core PCE, and breakeven inflation readings over the past
+      2 years. Core inputs for assessing Fed policy stance.
+    query_params:
+      metrics:
+        - cpi_yoy
+        - cpi_3m_annualized
+        - inflation_momentum
+        - core_pce_yoy
+        - pce_above_target
+        - breakeven_inflation_5y
+        - breakeven_inflation_10y
+        - breakeven_term_spread
+      group_by:
+        - "TimeDimension('inflation_month__signal_date', 'month')"
+
+  - name: labor_market_dashboard
+    label: Labor Market Dashboard
+    description: >
+      Monthly labor market composite: Sahm Rule, job openings/unemployed ratio,
+      unemployment rate, quits rate, and initial claims. Core inputs for
+      assessing recession risk and Fed dual-mandate.
+    query_params:
+      metrics:
+        - unemployment_rate
+        - labor_market_tightness
+        - labor_tightness_momentum
+        - sahm_rule_indicator
+        - worker_confidence
+        - initial_claims
+        - employment_population_ratio
+        - unrate_3m_momentum
+      group_by:
+        - "TimeDimension('labor_month__signal_date', 'month')"
+
+  - name: macro_indicators_by_series
+    label: Macro Indicators by FRED Series
+    description: >
+      Latest value and month-over-month change for each FRED economic series.
+      Use this to scan across GDP, rates, housing, and employment indicators
+      in a single query. Filter by series_code to drill into a specific indicator.
+    query_params:
+      metrics:
+        - fred_indicator_value
+        - fred_mom_change
+      group_by:
+        - "Dimension('fred_series__series_code')"
+        - "Dimension('fred_series__series_name')"
+        - "TimeDimension('fred_series__observation_date', 'month')"
+
+  - name: commodity_price_overview
+    label: Commodity Price Overview
+    description: >
+      1-month and 1-year returns for input commodities. Useful for tracking
+      cost-of-production pressures and upstream inflation signals.
+    query_params:
+      metrics:
+        - commodity_spot_price
+        - commodity_return_1mo
+        - commodity_return_1yr
+      group_by:
+        - "Dimension('commodity__commodity_name')"
+        - "Dimension('commodity__commodity_unit')"

--- a/dbt_project/models/semantic_layer/schema.yml
+++ b/dbt_project/models/semantic_layer/schema.yml
@@ -1,0 +1,14 @@
+version: 2
+
+models:
+  - name: time_spine_daily
+    description: Daily time spine used by MetricFlow for semantic-layer time joins.
+    time_spine:
+      standard_granularity_column: date_day
+    columns:
+      - name: date_day
+        description: Calendar date at daily grain.
+        granularity: day
+        tests:
+          - not_null
+          - unique

--- a/dbt_project/models/semantic_layer/time_spine_daily.sql
+++ b/dbt_project/models/semantic_layer/time_spine_daily.sql
@@ -1,0 +1,10 @@
+{{ config(materialized='table') }}
+
+SELECT date_day
+FROM UNNEST(
+    GENERATE_DATE_ARRAY(
+        DATE '2000-01-01',
+        DATE_ADD(CURRENT_DATE(), INTERVAL 30 DAY),
+        INTERVAL 1 DAY
+    )
+) AS date_day

--- a/dbt_project/models/signals/semantic_models.yml
+++ b/dbt_project/models/signals/semantic_models.yml
@@ -6,6 +6,8 @@ semantic_models:
       Monthly composite inflation signal model combining CPI, core PCE, and
       Treasury inflation breakeven rates. Grain: one row per month.
     model: ref('inflation_signals')
+    defaults:
+      agg_time_dimension: signal_date
     entities:
       - name: inflation_month
         type: primary
@@ -66,6 +68,8 @@ semantic_models:
       Monthly composite labor market signal model combining job openings,
       unemployment, claims, and the Sahm Rule. Grain: one row per month.
     model: ref('labor_signals')
+    defaults:
+      agg_time_dimension: signal_date
     entities:
       - name: labor_month
         type: primary

--- a/dbt_project/models/signals/semantic_models.yml
+++ b/dbt_project/models/signals/semantic_models.yml
@@ -1,0 +1,141 @@
+version: 2
+
+semantic_models:
+  - name: inflation_indicators
+    description: >
+      Monthly composite inflation signal model combining CPI, core PCE, and
+      Treasury inflation breakeven rates. Grain: one row per month.
+    model: ref('inflation_signals')
+    entities:
+      - name: inflation_month
+        type: primary
+        expr: "CAST(date AS VARCHAR)"
+    dimensions:
+      - name: signal_date
+        type: time
+        type_params:
+          time_granularity: month
+        expr: date
+      - name: cpi_momentum_status
+        type: categorical
+        description: "Categorical CPI momentum signal: high / medium / normal"
+      - name: core_pce_status
+        type: categorical
+        description: "Categorical core PCE signal: high / medium / normal"
+      - name: breakeven_status
+        type: categorical
+        description: "Categorical inflation expectations signal from breakeven rates"
+    measures:
+      - name: cpi_3m_annualized
+        agg: max
+        expr: cpi_3m_annualized
+        description: CPI 3-month annualized rate of change (%)
+      - name: cpi_12m_yoy
+        agg: max
+        expr: cpi_12m_yoy
+        description: CPI year-over-year percent change (%)
+      - name: cpi_momentum_spread
+        agg: max
+        expr: cpi_momentum_spread
+        description: Spread between 3m annualized and 12m YoY CPI (momentum indicator)
+      - name: core_pce_yoy
+        agg: max
+        expr: core_pce_yoy
+        description: Core PCE year-over-year percent change (%)
+      - name: pce_vs_target
+        agg: max
+        expr: pce_deviation_from_target
+        description: Core PCE deviation from 2% Fed target (positive = above target)
+      - name: breakeven_5y
+        agg: max
+        expr: breakeven_5y
+        description: 5-year Treasury inflation breakeven rate (%)
+      - name: breakeven_10y
+        agg: max
+        expr: breakeven_10y
+        description: 10-year Treasury inflation breakeven rate (%)
+      - name: breakeven_5y_10y_spread
+        agg: max
+        expr: breakeven_5y_10y_spread
+        description: >
+          5y minus 10y breakeven spread. Positive = near-term inflation expected
+          to exceed long-term (front-loaded inflation pressure).
+
+  - name: labor_market_indicators
+    description: >
+      Monthly composite labor market signal model combining job openings,
+      unemployment, claims, and the Sahm Rule. Grain: one row per month.
+    model: ref('labor_signals')
+    entities:
+      - name: labor_month
+        type: primary
+        expr: "CAST(date AS VARCHAR)"
+    dimensions:
+      - name: signal_date
+        type: time
+        type_params:
+          time_granularity: month
+        expr: date
+      - name: jo_ratio_status
+        type: categorical
+        description: >
+          Job openings / unemployed ratio signal:
+          high (JO >> unemployed, very tight), medium, normal, low (slack labor market)
+      - name: claims_trend_status
+        type: categorical
+        description: >
+          Initial claims 3-month trend signal:
+          high (claims rising >15%), medium (>10%), normal
+      - name: sahm_approx_status
+        type: categorical
+        description: >
+          Sahm Rule recession signal:
+          high (>= 0.5 — recession signal), medium (>= 0.3), normal
+      - name: quits_trend_status
+        type: categorical
+        description: >
+          Quits rate 3-month change signal:
+          high (declining sharply — workers less confident), medium, normal
+    measures:
+      - name: job_openings
+        agg: max
+        expr: job_openings
+        description: Monthly job openings count (thousands)
+      - name: unemployed_count
+        agg: max
+        expr: unemployed_count
+        description: Monthly unemployed persons count (thousands)
+      - name: jo_unemployed_ratio
+        agg: max
+        expr: jo_unemployed_ratio
+        description: Job openings / unemployed ratio (>1 = more openings than workers)
+      - name: unemployment_rate
+        agg: max
+        expr: unrate
+        description: Civilian unemployment rate (%)
+      - name: avg_monthly_claims
+        agg: max
+        expr: avg_monthly_claims
+        description: Average monthly initial jobless claims
+      - name: employment_ratio
+        agg: max
+        expr: emratio
+        description: Employment-population ratio (%)
+      - name: quits_rate
+        agg: max
+        expr: quits_rate
+        description: Job quits rate — proxy for worker confidence
+      - name: sahm_rule
+        agg: max
+        expr: sahm_approx
+        description: >
+          Sahm Rule indicator value. Threshold of 0.5 historically signals
+          recession onset. Based on 3-month average unemployment rate rise.
+      - name: jo_ratio_3m_change
+        agg: max
+        expr: jo_ratio_3m_change
+        description: 3-month change in job openings / unemployed ratio (momentum)
+      - name: unrate_3m_change
+        agg: max
+        expr: unrate_3m_change
+        description: 3-month change in unemployment rate (percentage points)


### PR DESCRIPTION
## Summary

- Adds MetricFlow `semantic_models:` for 10 dbt models across markets, commodities, government, and signals domains
- Defines 35 metrics covering equity returns, annualized volatility ratio, CPI/PCE/breakeven inflation gauges, Sahm Rule, job openings tightness, quits rate, and FRED indicator value/MoM change
- Adds 6 `saved_queries:` for common agent questions: equity performance ranking, sector rotation, inflation dashboard, labor market dashboard, FRED series scan, commodity overview

## Key design decisions

**Semantic models map to analysis/signal models (not raw/staging)** — these are the final grain-clean, documented models agents should query. Entities use composite string keys (`symbol|exchange`) to avoid ambiguous primary keys in multi-exchange data.

**Metrics focus on what agents ask** — trailing returns (1mo, 3mo, 6mo, 1yr), annualized volatility ratio (std/price), inflation momentum spread, Sahm Rule, and labor tightness ratio. All cross-reference FRED literature and Fed policy frameworks.

**Saved queries are agent-ready** — each query maps to a natural language question an LLM agent would ask (e.g., "which sectors are outperforming?", "is inflation re-accelerating?").

## Test plan

- [ ] `dbt parse` passes once BigQuery adapter is available in CI
- [ ] Run `dbt sl list metrics` to confirm all 35 metrics are registered
- [ ] Run `dbt sl query --metrics cpi_yoy --group-by inflation_month__signal_date` to smoke test inflation dashboard
- [ ] Run `dbt sl query --metrics sahm_rule_indicator --group-by labor_month__signal_date` to smoke test labor dashboard
- [ ] Verify saved queries execute without errors via `dbt sl query --saved-query equity_performance_by_symbol`

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)